### PR TITLE
Add pre-commit config and hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest --cov=loop_bloom --cov-fail-under=80 -q
+        language: system
+        pass_filenames: false

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+flake8
+mypy loop_bloom
+PYTHONPATH=. pytest --cov=loop_bloom --cov-fail-under=80 -q


### PR DESCRIPTION
## Summary
- add a pre-commit configuration running flake8, mypy and pytest with coverage >=80%
- include a `scripts/pre-commit` helper that can be copied to `.git/hooks`

## Testing
- `scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68476b8051cc8322ae93984c06e820bc