### PR TITLE
Use config defaults for progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ flowchart TD
 ```
 
 Parameters `threshold` and `window` are user-configurable.
+When omitted by commands, the progression rule reads these values from
+`~/.config/loopbloom/config.toml`.
 
 <a id="notifications"></a>
 

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import List
 
+from loopbloom.core import config as cfg
 from loopbloom.core.models import Checkin, MicroGoal
 
 WINDOW_DEFAULT = 14  # days
@@ -23,10 +24,22 @@ def _recent_checkins(checkins: List[Checkin], window: int) -> List[Checkin]:
 def should_advance(
     micro: MicroGoal,
     *,
-    window: int = WINDOW_DEFAULT,
-    threshold: float = THRESHOLD_DEFAULT,
+    window: int | None = None,
+    threshold: float | None = None,
 ) -> bool:
-    """Return True if micro-habit qualifies for advancement."""
+    """Return True if micro-habit qualifies for advancement.
+
+    If ``window`` or ``threshold`` are omitted, values are read from
+    ``loopbloom.core.config`` (keys ``advance.window`` and
+    ``advance.threshold``).
+    """
+    if window is None or threshold is None:
+        conf = cfg.load().get("advance", {})
+        if window is None:
+            window = int(conf.get("window", WINDOW_DEFAULT))
+        if threshold is None:
+            threshold = float(conf.get("threshold", THRESHOLD_DEFAULT))
+
     recent = _recent_checkins(micro.checkins, window)
     if len(recent) < window:  # need full window
         return False

--- a/tests/unit/test_progression.py
+++ b/tests/unit/test_progression.py
@@ -25,3 +25,15 @@ def test_should_advance_edge_cases(successes, total, expected):
         day = TODAY - timedelta(days=i)
         mg.checkins.append(Checkin(date=day, success=i < successes))
     assert should_advance(mg) is expected
+
+
+def test_should_advance_respects_config(monkeypatch) -> None:
+    """Changing config alters advancement logic."""
+    mg = MicroGoal(name="Cfg")
+    mg.checkins.append(Checkin(date=TODAY, success=True))
+    mg.checkins.append(Checkin(date=TODAY - timedelta(days=1), success=False))
+    monkeypatch.setattr(
+        "loopbloom.core.config.load",
+        lambda: {"advance": {"threshold": 0.5, "window": 2}},
+    )
+    assert should_advance(mg)


### PR DESCRIPTION
## Summary
- read `advance.window`/`advance.threshold` in progression helper when no args
- use configured window in summary banner
- test config-aware progression behaviour
- document that the progression engine reads its defaults from config

## Testing
- `ruff check --fix loopbloom/core/progression.py loopbloom/cli/summary.py tests/unit/test_progression.py`
- `black loopbloom/core/progression.py loopbloom/cli/summary.py tests/unit/test_progression.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490cfd40808322a1cc15ba54db22c0