### PR TITLE
Fix help wrapping

### DIFF
--- a/loopbloom/cli/__init__.py
+++ b/loopbloom/cli/__init__.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path  # noqa: F401
 from typing import Any, Callable, List
+from functools import wraps
 
 import click
 
@@ -27,6 +28,7 @@ def save_goals(goals: List[GoalArea]) -> None:
 def with_goals(f: Callable[..., Any]) -> Callable[..., Any]:
     """Load goals for ``f`` then save afterwards."""  # noqa: D401
 
+    @wraps(f)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         goals = load_goals()
         result = f(*args, goals=goals, **kwargs)

--- a/loopbloom/tests/test_cli_help.py
+++ b/loopbloom/tests/test_cli_help.py
@@ -14,3 +14,5 @@ def test_cli_help() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+    assert "goal" in result.stdout
+    assert "summary" in result.stdout


### PR DESCRIPTION
## Summary
- preserve original CLI function metadata when applying with_goals decorator
- verify CLI help lists subcommands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849813e685c83229a653d8ccc73cf29