### PR TITLE
Add MicroGoal name trimming test

### DIFF
--- a/loopbloom/tests/unit/test_models.py
+++ b/loopbloom/tests/unit/test_models.py
@@ -33,3 +33,9 @@ def test_checkin_success_ratio() -> None:
 def test_status_enum() -> None:
     """Enum members expose the correct value."""
     assert Status.active.value == "active"
+
+
+def test_microgoal_name_trimmed() -> None:
+    """Whitespace is stripped from names."""
+    mg = MicroGoal(name="  Walk  ")
+    assert mg.name == "Walk"


### PR DESCRIPTION
## Summary
- ensure whitespace is stripped from MicroGoal names

## Testing
- `pytest -k test_microgoal_name_trimmed -q`

------
https://chatgpt.com/codex/tasks/task_e_684a4ff6a1448322b58c2d54618d096b