### PR TITLE
Add goal hierarchy tree command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Traditional trackers assume unlimited will-power and demand elaborate setups. **
 | **Smart Progression**   | ≥ 80 % over 14 days triggers *advance* prompt.                     | 
 | **Guided Coping**       | `cope` launches YAML Q\&A scripts for overwhelm.                   | 
 | **Gentle Banners**      | `summary` prints streaks, nudges, celebrations. Optional `--goal`. | 
+| **Tree View**           | `tree` shows your goals, phases, and micro-habits. |
 | **Exports**             | \`export csv/json                                                  | 
 | **Pluggable Storage**   | JSON by default; SQLite plugin for power-users.                    | 
 | **100 % Test Coverage** | Every line & branch, enforced by CI.                               | 
@@ -139,6 +140,7 @@ GOALS & MICRO-HABITS
   loopbloom goal  list|add|edit|rm                # manage goal areas
   loopbloom phase list|add|edit|rm                # optional phases
   loopbloom micro list|add|edit|rm|start|cancel   # micro-habit operations
+  loopbloom tree                         # show goal hierarchy
 
 CHECK-INS & FEEDBACK
   loopbloom checkin   [--goal <name>] [--status done|skip] [--note ..]

--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -10,6 +10,7 @@ from loopbloom.cli.config import config  # NEW
 from loopbloom.cli.cope import cope  # NEW
 from loopbloom.cli.export import export  # NEW
 from loopbloom.cli.goal import goal
+from loopbloom.cli.tree import tree
 from loopbloom.cli.summary import summary
 
 if TYPE_CHECKING:  # pragma: no cover - hints for mypy
@@ -29,6 +30,7 @@ cli.add_command(summary)  # NEW
 cli.add_command(cope)
 cli.add_command(config)
 cli.add_command(export)
+cli.add_command(tree)
 
 if __name__ == "__main__":
     cli()

--- a/loopbloom/cli/tree.py
+++ b/loopbloom/cli/tree.py
@@ -1,0 +1,26 @@
+"""Goal hierarchy tree command."""
+
+from typing import List
+
+import click
+from rich.console import Console
+from rich.tree import Tree
+
+from loopbloom.cli import with_goals
+from loopbloom.core.models import GoalArea
+
+console = Console()
+
+
+@click.command(name="tree", help="Show goal hierarchy as a tree.")
+@with_goals
+def tree(ctx: click.Context, goals: List[GoalArea]) -> None:
+    """Display all goals, phases, and micro-habits in a tree view."""
+    root = Tree("\U0001F333 LoopBloom Goals")
+    for g in goals:
+        g_branch = root.add(g.name)
+        for ph in g.phases:
+            p_branch = g_branch.add(ph.name)
+            for m in ph.micro_goals:
+                p_branch.add(m.name)
+    console.print(root)

--- a/tests/integration/test_tree_cmd.py
+++ b/tests/integration/test_tree_cmd.py
@@ -1,0 +1,42 @@
+"""Integration tests for the tree CLI command."""
+
+import importlib
+import os
+
+from click.testing import CliRunner
+
+
+def test_tree_displays_hierarchy(tmp_path) -> None:
+    """Ensure tree output includes goal, phase, and micro names."""
+    runner = CliRunner()
+    data_file = tmp_path / "data.json"
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
+
+    import loopbloom.cli as cli_mod
+    import loopbloom.cli.goal as goal_mod
+    import loopbloom.cli.tree as tree_mod
+    import loopbloom.storage.json_store as js_mod
+    from loopbloom import __main__ as main
+
+    importlib.reload(js_mod)
+    importlib.reload(cli_mod)
+    importlib.reload(goal_mod)
+    importlib.reload(tree_mod)
+    importlib.reload(main)
+
+    cli = main.cli
+
+    runner.invoke(cli, ["goal", "add", "Exercise"], env=env)
+    runner.invoke(cli, ["goal", "phase", "add", "Exercise", "Base"], env=env)
+    runner.invoke(
+        cli,
+        ["goal", "micro", "add", "Exercise", "Base", "Walk"],
+        env=env,
+    )
+
+    res = runner.invoke(cli, ["tree"], env=env)
+    assert "Exercise" in res.output
+    assert "Base" in res.output
+    assert "Walk" in res.output


### PR DESCRIPTION
## Summary
- add `tree` CLI command for displaying goals in a tree
- document new tree command in README
- test the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5054b5e48322836e9c1952392fa6