### PR TITLE
Add interactive selection for CLI

### DIFF
--- a/loopbloom/cli/__init__.py
+++ b/loopbloom/cli/__init__.py
@@ -1,8 +1,8 @@
 """CLI storage loader and saver for LoopBloom."""
 
+from functools import wraps
 from pathlib import Path  # noqa: F401
 from typing import Any, Callable, List
-from functools import wraps
 
 import click
 

--- a/loopbloom/cli/interactive.py
+++ b/loopbloom/cli/interactive.py
@@ -16,5 +16,5 @@ def choose_from(options: Iterable[T], prompt: str) -> Optional[T]:
         return None
     for i, opt in enumerate(items, 1):
         click.echo(f"{i}. {opt}")
-    idx = click.prompt("Enter number", type=click.IntRange(1, len(items)))
+    idx: int = click.prompt(prompt, type=click.IntRange(1, len(items)))
     return items[idx - 1]

--- a/loopbloom/cli/interactive.py
+++ b/loopbloom/cli/interactive.py
@@ -1,0 +1,20 @@
+"""Interactive CLI helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, TypeVar
+
+import click
+
+T = TypeVar("T")
+
+
+def choose_from(options: Iterable[T], prompt: str) -> Optional[T]:
+    """Show numbered menu of ``options`` and return the chosen item."""
+    items: List[T] = list(options)
+    if not items:
+        return None
+    for i, opt in enumerate(items, 1):
+        click.echo(f"{i}. {opt}")
+    idx = click.prompt("Enter number", type=click.IntRange(1, len(items)))
+    return items[idx - 1]

--- a/tests/integration/test_interactive_selection.py
+++ b/tests/integration/test_interactive_selection.py
@@ -1,0 +1,43 @@
+"""Tests for interactive selection menus."""
+
+import importlib
+import json
+import os
+
+from click.testing import CliRunner
+
+from loopbloom import __main__ as main
+
+
+def test_checkin_prompts_for_goal(tmp_path) -> None:
+    """Check that missing args trigger goal selection prompt."""
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(tmp_path / "data.json")
+    import loopbloom.cli as cli_mod
+    import loopbloom.cli.checkin as checkin_mod
+    import loopbloom.cli.goal as goal_mod
+    import loopbloom.storage.json_store as js_mod
+
+    importlib.reload(js_mod)
+    importlib.reload(cli_mod)
+    importlib.reload(goal_mod)
+    importlib.reload(checkin_mod)
+    importlib.reload(main)
+    cli = main.cli
+
+    # setup
+    runner.invoke(cli, ["goal", "add", "Sleep"], env=env)
+    runner.invoke(cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)
+    runner.invoke(cli, ["goal", "micro", "add", "Sleep", "Base", "Lights"], env=env)
+
+    res = runner.invoke(cli, ["checkin"], env=env, input="1\n")
+    assert "Which goal do you want to check in for?" in res.output
+
+    data = json.loads((tmp_path / "data.json").read_text())
+    checks = data[0]["phases"][0]["micro_goals"][0]["checkins"]
+    assert len(checks) == 1
+
+
+

--- a/tests/integration/test_interactive_selection.py
+++ b/tests/integration/test_interactive_selection.py
@@ -30,7 +30,11 @@ def test_checkin_prompts_for_goal(tmp_path) -> None:
     # setup
     runner.invoke(cli, ["goal", "add", "Sleep"], env=env)
     runner.invoke(cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)
-    runner.invoke(cli, ["goal", "micro", "add", "Sleep", "Base", "Lights"], env=env)
+    runner.invoke(
+        cli,
+        ["goal", "micro", "add", "Sleep", "Base", "Lights"],
+        env=env,
+    )
 
     res = runner.invoke(cli, ["checkin"], env=env, input="1\n")
     assert "Which goal do you want to check in for?" in res.output
@@ -38,6 +42,3 @@ def test_checkin_prompts_for_goal(tmp_path) -> None:
     data = json.loads((tmp_path / "data.json").read_text())
     checks = data[0]["phases"][0]["micro_goals"][0]["checkins"]
     assert len(checks) == 1
-
-
-


### PR DESCRIPTION
## Summary
- support interactive numbered menus when goal or phase names are omitted
- add helper `choose_from` in `loopbloom/cli/interactive.py`
- use interactive prompts in goal, phase, and micro CLI commands
- allow goal selection for `checkin`
- test interactive menu behavior

## Testing
- `ruff check tests/integration/test_interactive_selection.py loopbloom/cli/interactive.py loopbloom/cli/checkin.py loopbloom/cli/goal.py`
- `ruff check loopbloom/cli/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a503c174c8322915b5b78f8d00ddc