### PR TITLE
Fix CLI script name in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ types-PyYAML = "*"
 tomli-w = "*"
 
 [tool.poetry.scripts]
-micro = "loopbloom.__main__:cli"
+loopbloom = "loopbloom.__main__:cli"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- rename CLI script from **micro** to **loopbloom** in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `pydantic`, `tomli_w`, and others)*

------
https://chatgpt.com/codex/tasks/task_e_684a542fb87c8322ae4555973e005e00