### PR TITLE
Add CLI config tests

### DIFF
--- a/tests/unit/test_config_module.py
+++ b/tests/unit/test_config_module.py
@@ -1,5 +1,7 @@
 """Unit tests for config module."""
 
+from click.testing import CliRunner
+
 from loopbloom.core import config as cfg
 
 
@@ -9,3 +11,53 @@ def test_deep_merge() -> None:
     b = {"b": {"d": 3}}
     merged = cfg._deep_merge(a, b)
     assert merged["b"]["c"] == 2 and merged["b"]["d"] == 3
+
+
+def test_cli_set_casts_integer(tmp_path, monkeypatch) -> None:
+    """Setting a numeric value results in an int in the config."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    import importlib
+    import loopbloom.core.config as cfg_mod
+    import loopbloom.cli.config as cli_cfg
+
+    importlib.reload(cfg_mod)
+    importlib.reload(cli_cfg)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_cfg._set, ["advance.window", "20"])
+    assert "Saved." in result.output
+    assert cfg_mod.load()["advance"]["window"] == 20
+
+
+def test_cli_set_casts_boolean(tmp_path, monkeypatch) -> None:
+    """Setting a boolean string stores ``True`` in the config."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    import importlib
+    import loopbloom.core.config as cfg_mod
+    import loopbloom.cli.config as cli_cfg
+
+    importlib.reload(cfg_mod)
+    importlib.reload(cli_cfg)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_cfg._set, ["notify", "true"])
+    assert "Saved." in result.output
+    assert cfg_mod.load()["notify"] is True
+
+
+def test_cli_get_missing_key(tmp_path, monkeypatch) -> None:
+    """Getting an unknown key shows an error message."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    import importlib
+    import loopbloom.core.config as cfg_mod
+    import loopbloom.cli.config as cli_cfg
+
+    importlib.reload(cfg_mod)
+    importlib.reload(cli_cfg)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_cfg._get, ["nonexistent.key"])
+    assert "[red]Key not found." in result.output


### PR DESCRIPTION
## Summary
- extend config module tests with CLI interaction

## Testing
- `pytest tests/unit/test_config_module.py`


------
https://chatgpt.com/codex/tasks/task_e_684a53e077fc832286dc6993d289ff7b