### PR TITLE
Enhance error feedback in CLI

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -6,6 +6,7 @@ import click
 from rich import print
 
 from loopbloom.cli import with_goals
+from loopbloom.cli.utils import goal_not_found
 from loopbloom.cli.interactive import choose_from
 from loopbloom.core.models import Checkin, GoalArea
 from loopbloom.core.talks import TalkPool
@@ -43,7 +44,7 @@ def checkin(
         None,
     )
     if not goal:
-        click.echo("[red]Goal not found.")
+        goal_not_found(goal_name, [g.name for g in goals])
         return
     # Find first phase with an active micro-goal
     mg = None

--- a/loopbloom/cli/config.py
+++ b/loopbloom/cli/config.py
@@ -29,6 +29,7 @@ def _get(key: str) -> None:
         val = val.get(part) if isinstance(val, dict) else None
     if val is None:
         click.echo("[red]Key not found.")
+        click.echo("Run 'loopbloom config view' to inspect available keys.")
     else:
         click.echo(val)
 

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import click
 
 from loopbloom.cli import with_goals
+from loopbloom.cli.utils import goal_not_found
 from loopbloom.cli.interactive import choose_from
 from loopbloom.core.models import GoalArea, MicroGoal, Phase, Status
 
@@ -74,7 +75,7 @@ def goal_rm(
 
     g = _find_goal(goals, name)
     if not g:
-        click.echo("[red]Goal not found.")
+        goal_not_found(name, [g.name for g in goals])
         return
     if not yes and not click.confirm(
         f"Delete goal '{name}'?",
@@ -115,7 +116,7 @@ def phase_add(
 
     g = _find_goal(goals, goal_name)
     if not g:
-        click.echo("[red]Goal not found.")
+        goal_not_found(goal_name, [x.name for x in goals])
         return
     if _find_phase(g, phase_name):
         click.echo("[yellow]Phase exists.")
@@ -157,7 +158,7 @@ def micro_add(
     g = _find_goal(goals, goal_name)
     if phase_name is None:
         if not g:
-            click.echo("[red]Goal not found.")
+            goal_not_found(goal_name, [x.name for x in goals])
             return
         options = [p.name for p in g.phases]
         if not options:
@@ -171,6 +172,7 @@ def micro_add(
     p = _find_phase(g, phase_name) if g else None
     if not p:
         click.echo("[red]Goal or phase not found.")
+        click.echo("Run 'loopbloom goal list' to see your available goals.")
         return
     p.micro_goals.append(MicroGoal(name=micro_name.strip()))
     message = (
@@ -210,7 +212,7 @@ def micro_cancel(
     g = _find_goal(goals, goal_name)
     if phase_name is None:
         if not g:
-            click.echo("[red]Goal not found.")
+            goal_not_found(goal_name, [x.name for x in goals])
             return
         options = [p.name for p in g.phases]
         if not options:
@@ -224,6 +226,7 @@ def micro_cancel(
     p = _find_phase(g, phase_name) if g else None
     if not p:
         click.echo("[red]Goal or phase not found.")
+        click.echo("Run 'loopbloom goal list' to see your available goals.")
         return
 
     if micro_name is None:
@@ -239,6 +242,7 @@ def micro_cancel(
     mg = next((m for m in p.micro_goals if m.name == micro_name), None)
     if not mg:
         click.echo("[red]Micro-habit not found.")
+        click.echo("Run 'loopbloom goal list' to see your available goals.")
         return
     mg.status = Status.cancelled
     click.echo(f"[yellow]Cancelled micro-habit:[/] {micro_name}")

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from rich.progress_bar import ProgressBar
 
 from loopbloom.cli import with_goals
+from loopbloom.cli.utils import goal_not_found
 from loopbloom.core import config as cfg
 from loopbloom.core.models import GoalArea
 from loopbloom.core.progression import should_advance
@@ -82,7 +83,7 @@ def _detail_view(goal_name: str, goals: List[GoalArea]) -> None:
     window = cfg.load().get("advance", {}).get("window", WINDOW_DEFAULT)
     g = next((x for x in goals if x.name.lower() == goal_name.lower()), None)
     if not g:
-        click.echo("[red]Goal not found.")
+        goal_not_found(goal_name, [x.name for x in goals])
         return
     # find active micro
     mg = None

--- a/loopbloom/cli/utils.py
+++ b/loopbloom/cli/utils.py
@@ -1,0 +1,23 @@
+"""Utility helpers for friendlier CLI error messages."""
+
+from __future__ import annotations
+
+from difflib import get_close_matches
+from typing import Iterable
+
+import click
+
+
+def suggest_name(name: str, options: Iterable[str]) -> str | None:
+    """Return a close match for ``name`` from ``options`` if available."""
+    matches = get_close_matches(name, list(options), n=1)
+    return matches[0] if matches else None
+
+
+def goal_not_found(name: str, goals: Iterable[str]) -> None:
+    """Print helpful message when a goal is missing."""
+    click.echo(f"[red]Goal not found: \"{name}\".[/red]")
+    match = suggest_name(name, goals)
+    if match:
+        click.echo(f"\nDid you mean \"{match}\"?")
+    click.echo("Run 'loopbloom goal list' to see your available goals.")

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -90,7 +90,7 @@ def test_goal_rm_missing(tmp_path) -> None:
     cli = main.cli
 
     res = runner.invoke(cli, ["goal", "rm", "Ghost", "--yes"], env=env)
-    assert "Goal not found." in res.output
+    assert "Goal not found" in res.output
 
 
 def test_phase_add_missing_goal(tmp_path) -> None:
@@ -119,4 +119,4 @@ def test_phase_add_missing_goal(tmp_path) -> None:
         ["goal", "phase", "add", "Ghost", "Base"],
         env=env,
     )
-    assert "[red]Goal not found." in res.output
+    assert "[red]Goal not found" in res.output


### PR DESCRIPTION
## Summary
- add utilities for helpful error messages
- suggest similar goals when checkin/summary/goal commands fail
- include next steps for config key errors
- adjust tests for updated messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa4b251648322a630913d197e60d7