### PR TITLE
Add direct micro-goals on GoalArea

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -46,12 +46,18 @@ def checkin(
     if not goal:
         goal_not_found(goal_name, [g.name for g in goals])
         return
-    # Find first phase with an active micro-goal
+    # Find the active micro-goal
     mg = None
+    # First, search in phases
     for ph in goal.phases:
         mg = next((m for m in ph.micro_goals if m.status == "active"), None)
         if mg:
             break
+
+    # If not found, search in direct micro-goals
+    if mg is None:
+        mg = next((m for m in goal.micro_goals if m.status == "active"), None)
+
     if mg is None:
         click.echo("[red]No active micro-goal found for this goal.")
         return

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -7,7 +7,7 @@ import click
 from loopbloom.cli import with_goals
 from loopbloom.cli.utils import goal_not_found
 from loopbloom.cli.interactive import choose_from
-from loopbloom.core.models import GoalArea, MicroGoal, Phase, Status
+from loopbloom.core.models import GoalArea, MicroGoal, Phase
 
 
 def _find_goal(goals: List[GoalArea], name: str) -> Optional[GoalArea]:
@@ -134,8 +134,18 @@ def micro() -> None:
 
 @micro.command(name="add")
 @click.argument("name")
-@click.option("--goal", "goal_name", required=True, help="The goal to add this to.")
-@click.option("--phase", "phase_name", default=None, help="Add to a specific phase.")
+@click.option(
+    "--goal",
+    "goal_name",
+    required=True,
+    help="The goal to add this to.",
+)
+@click.option(
+    "--phase",
+    "phase_name",
+    default=None,
+    help="Add to a specific phase.",
+)
 @with_goals
 def micro_add(
     ctx: click.Context,
@@ -157,16 +167,30 @@ def micro_add(
 
     p = _find_phase(g, phase_name)
     if not p:
-        click.echo(f"[red]Phase '{phase_name}' not found in goal '{goal_name}'.")
+        click.echo(
+            f"[red]Phase '{phase_name}' not found in goal '{goal_name}'."
+        )
         return
     p.micro_goals.append(MicroGoal(name=name.strip()))
-    click.echo(f"[green]Added micro-habit '{name}' to {goal_name}/{phase_name}")
+    click.echo(
+        f"[green]Added micro-habit '{name}' to {goal_name}/{phase_name}"
+    )
 
 
 @micro.command(name="rm")
 @click.argument("name")
-@click.option("--goal", "goal_name", required=True, help="The goal to remove from.")
-@click.option("--phase", "phase_name", default=None, help="Remove from a specific phase.")
+@click.option(
+    "--goal",
+    "goal_name",
+    required=True,
+    help="The goal to remove from.",
+)
+@click.option(
+    "--phase",
+    "phase_name",
+    default=None,
+    help="Remove from a specific phase.",
+)
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
 @with_goals
 def micro_rm(
@@ -199,7 +223,9 @@ def micro_rm(
         click.echo(f"[red]Micro-habit '{name}' not found in {loc}.")
         return
 
-    if not yes and not click.confirm(f"Permanently delete '{name}'?", default=False):
+    if not yes and not click.confirm(
+        f"Permanently delete '{name}'?", default=False
+    ):
         return
 
     target_list.remove(mg)

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -75,11 +75,17 @@ def _overview(goals: List[GoalArea]) -> None:
         # Update logic to find the active micro-goal
         active = None
         for ph in g.phases:
-            active = next((m for m in ph.micro_goals if m.status == "active"), None)
+            active = next(
+                (m for m in ph.micro_goals if m.status == "active"),
+                None,
+            )
             if active:
                 break
         if active is None:
-            active = next((m for m in g.micro_goals if m.status == "active"), None)
+            active = next(
+                (m for m in g.micro_goals if m.status == "active"),
+                None,
+            )
         flag = "Advance?" if active and should_advance(active) else "\u2014"
         table.add_row(g.name, ratio, flag)
     console.print(table)

--- a/loopbloom/cli/tree.py
+++ b/loopbloom/cli/tree.py
@@ -19,8 +19,12 @@ def tree(ctx: click.Context, goals: List[GoalArea]) -> None:
     root = Tree("\U0001F333 LoopBloom Goals")
     for g in goals:
         g_branch = root.add(g.name)
+        # Add micro-goals in phases
         for ph in g.phases:
-            p_branch = g_branch.add(ph.name)
+            p_branch = g_branch.add(f"[dim]Phase:[/] {ph.name}")
             for m in ph.micro_goals:
                 p_branch.add(m.name)
+        # Add direct micro-goals
+        for m in g.micro_goals:
+            g_branch.add(m.name)
     console.print(root)

--- a/loopbloom/core/models.py
+++ b/loopbloom/core/models.py
@@ -56,4 +56,5 @@ class GoalArea(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str
     phases: list[Phase] = Field(default_factory=list)
+    micro_goals: list[MicroGoal] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/tests/integration/test_checkin_and_summary.py
+++ b/tests/integration/test_checkin_and_summary.py
@@ -19,7 +19,16 @@ def test_checkin_generates_peptalk_and_summary(tmp_path) -> None:
     )
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Walk 5 min",
+            "--goal",
+            "Exercise",
+            "--phase",
+            "Foundation",
+        ],
         env=env,
     )
 

--- a/tests/integration/test_checkin_and_summary.py
+++ b/tests/integration/test_checkin_and_summary.py
@@ -19,7 +19,7 @@ def test_checkin_generates_peptalk_and_summary(tmp_path) -> None:
     )
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Exercise", "Foundation", "Walk 5 min"],
+        ["goal", "micro", "add", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation"],
         env=env,
     )
 

--- a/tests/integration/test_direct_microgoals.py
+++ b/tests/integration/test_direct_microgoals.py
@@ -39,10 +39,14 @@ def test_direct_microgoal_workflow(tmp_path):
 
     # 2. Add Micro-Goal directly to Goal
     res_add = runner.invoke(
-        cli, ["goal", "micro", "add", "Read 1 page", "--goal", "Reading"], env=env
+        cli,
+        ["goal", "micro", "add", "Read 1 page", "--goal", "Reading"],
+        env=env,
     )
     assert res_add.exit_code == 0
-    assert "Added micro-habit 'Read 1 page' to goal 'Reading'" in res_add.output
+    assert (
+        "Added micro-habit 'Read 1 page' to goal 'Reading'" in res_add.output
+    )
 
     # 3. Verify with `tree`
     res_tree = runner.invoke(cli, ["tree"], env=env)
@@ -59,7 +63,9 @@ def test_direct_microgoal_workflow(tmp_path):
 
     # 5. Remove micro-goal
     res_rm = runner.invoke(
-        cli, ["goal", "micro", "rm", "Read 1 page", "--goal", "Reading", "--yes"], env=env
+        cli,
+        ["goal", "micro", "rm", "Read 1 page", "--goal", "Reading", "--yes"],
+        env=env,
     )
     assert "Deleted micro-habit" in res_rm.output
 

--- a/tests/integration/test_direct_microgoals.py
+++ b/tests/integration/test_direct_microgoals.py
@@ -1,0 +1,67 @@
+import json
+import os
+import importlib
+from click.testing import CliRunner
+
+
+def _reload_cli_modules():
+    """Helper to reload modules to pick up changes."""
+    import sys
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    import loopbloom.cli.goal as goal_mod
+    import loopbloom.cli.tree as tree_mod
+    import loopbloom.cli as cli_mod
+    import loopbloom.storage.json_store as js_mod
+    from loopbloom import __main__ as main
+    importlib.reload(js_mod)
+    importlib.reload(cli_mod)
+    importlib.reload(goal_mod)
+    importlib.reload(tree_mod)
+    importlib.reload(main)
+    return main.cli
+
+
+def test_direct_microgoal_workflow(tmp_path):
+    """Test CRUD, tree, and check-in for phase-less micro-goals."""
+    runner = CliRunner()
+    data_file = tmp_path / "data.json"
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    # Ensure env var is set for reloads
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
+    cli = _reload_cli_modules()
+
+    # 1. Add Goal
+    runner.invoke(cli, ["goal", "add", "Reading"], env=env)
+
+    # 2. Add Micro-Goal directly to Goal
+    res_add = runner.invoke(
+        cli, ["goal", "micro", "add", "Read 1 page", "--goal", "Reading"], env=env
+    )
+    assert res_add.exit_code == 0
+    assert "Added micro-habit 'Read 1 page' to goal 'Reading'" in res_add.output
+
+    # 3. Verify with `tree`
+    res_tree = runner.invoke(cli, ["tree"], env=env)
+    assert "Reading" in res_tree.output
+    assert "Phase" not in res_tree.output
+    assert "Read 1 page" in res_tree.output
+
+    # 4. Check in
+    res_checkin = runner.invoke(cli, ["checkin", "Reading"], env=env)
+    assert "\u2713" in res_checkin.output
+
+    data = json.loads(data_file.read_text())
+    assert len(data[0]["micro_goals"][0]["checkins"]) == 1
+
+    # 5. Remove micro-goal
+    res_rm = runner.invoke(
+        cli, ["goal", "micro", "rm", "Read 1 page", "--goal", "Reading", "--yes"], env=env
+    )
+    assert "Deleted micro-habit" in res_rm.output
+
+    data_after_rm = json.loads(data_file.read_text())
+    assert len(data_after_rm[0]["micro_goals"]) == 0

--- a/tests/integration/test_export_and_config_cmds.py
+++ b/tests/integration/test_export_and_config_cmds.py
@@ -42,7 +42,16 @@ def test_export_json_and_csv(tmp_path):
     runner.invoke(main.cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)
     runner.invoke(
         main.cli,
-        ["goal", "micro", "add", "Wake 8", "--goal", "Sleep", "--phase", "Base"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Wake 8",
+            "--goal",
+            "Sleep",
+            "--phase",
+            "Base",
+        ],
         env=env,
     )
     runner.invoke(main.cli, ["checkin", "Sleep"], env=env)

--- a/tests/integration/test_export_and_config_cmds.py
+++ b/tests/integration/test_export_and_config_cmds.py
@@ -42,7 +42,7 @@ def test_export_json_and_csv(tmp_path):
     runner.invoke(main.cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)
     runner.invoke(
         main.cli,
-        ["goal", "micro", "add", "Sleep", "Base", "Wake 8"],
+        ["goal", "micro", "add", "Wake 8", "--goal", "Sleep", "--phase", "Base"],
         env=env,
     )
     runner.invoke(main.cli, ["checkin", "Sleep"], env=env)

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -50,7 +50,7 @@ def test_goal_phase_micro_crud(tmp_path):
     # Add micro-habit
     res = runner.invoke(
         cli,
-        ["goal", "micro", "add", "Exercise", "Foundation", "Walk 5 min"],
+        ["goal", "micro", "add", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation"],
         env=env,
     )
     assert "Added micro-habit" in res.output
@@ -58,14 +58,14 @@ def test_goal_phase_micro_crud(tmp_path):
     # Cancel micro-habit
     res = runner.invoke(
         cli,
-        ["goal", "micro", "cancel", "Exercise", "Foundation", "Walk 5 min"],
+        ["goal", "micro", "rm", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation", "--yes"],
         env=env,
     )
-    assert "Cancelled micro-habit" in res.output
+    assert "Deleted micro-habit" in res.output
 
     # Verify JSON structure saved
     data = json.loads(data_file.read_text())
-    assert data[0]["phases"][0]["micro_goals"][0]["status"] == "cancelled"
+    assert data[0]["phases"][0]["micro_goals"] == []
 
 
 def test_goal_rm_missing(tmp_path) -> None:

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -50,7 +50,16 @@ def test_goal_phase_micro_crud(tmp_path):
     # Add micro-habit
     res = runner.invoke(
         cli,
-        ["goal", "micro", "add", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Walk 5 min",
+            "--goal",
+            "Exercise",
+            "--phase",
+            "Foundation",
+        ],
         env=env,
     )
     assert "Added micro-habit" in res.output
@@ -58,7 +67,17 @@ def test_goal_phase_micro_crud(tmp_path):
     # Cancel micro-habit
     res = runner.invoke(
         cli,
-        ["goal", "micro", "rm", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation", "--yes"],
+        [
+            "goal",
+            "micro",
+            "rm",
+            "Walk 5 min",
+            "--goal",
+            "Exercise",
+            "--phase",
+            "Foundation",
+            "--yes",
+        ],
         env=env,
     )
     assert "Deleted micro-habit" in res.output

--- a/tests/integration/test_interactive_selection.py
+++ b/tests/integration/test_interactive_selection.py
@@ -32,7 +32,16 @@ def test_checkin_prompts_for_goal(tmp_path) -> None:
     runner.invoke(cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Lights", "--goal", "Sleep", "--phase", "Base"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Lights",
+            "--goal",
+            "Sleep",
+            "--phase",
+            "Base",
+        ],
         env=env,
     )
 

--- a/tests/integration/test_interactive_selection.py
+++ b/tests/integration/test_interactive_selection.py
@@ -32,7 +32,7 @@ def test_checkin_prompts_for_goal(tmp_path) -> None:
     runner.invoke(cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Sleep", "Base", "Lights"],
+        ["goal", "micro", "add", "Lights", "--goal", "Sleep", "--phase", "Base"],
         env=env,
     )
 

--- a/tests/integration/test_notify_and_sqlite.py
+++ b/tests/integration/test_notify_and_sqlite.py
@@ -37,7 +37,16 @@ def test_switch_to_sqlite_and_notify(tmp_path, monkeypatch):
     )
     runner.invoke(
         new_cli,
-        ["goal", "micro", "add", "Test", "--goal", "NotifyGoal", "--phase", "Base"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Test",
+            "--goal",
+            "NotifyGoal",
+            "--phase",
+            "Base",
+        ],
         env=env,
     )
 

--- a/tests/integration/test_notify_and_sqlite.py
+++ b/tests/integration/test_notify_and_sqlite.py
@@ -37,7 +37,7 @@ def test_switch_to_sqlite_and_notify(tmp_path, monkeypatch):
     )
     runner.invoke(
         new_cli,
-        ["goal", "micro", "add", "NotifyGoal", "Base", "Test"],
+        ["goal", "micro", "add", "Test", "--goal", "NotifyGoal", "--phase", "Base"],
         env=env,
     )
 

--- a/tests/integration/test_progression_summary.py
+++ b/tests/integration/test_progression_summary.py
@@ -46,7 +46,16 @@ def test_summary_shows_advance_prompt(tmp_path):
     )
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Walk 5 min",
+            "--goal",
+            "Exercise",
+            "--phase",
+            "Foundation",
+        ],
         env=env,
     )
 

--- a/tests/integration/test_progression_summary.py
+++ b/tests/integration/test_progression_summary.py
@@ -46,7 +46,7 @@ def test_summary_shows_advance_prompt(tmp_path):
     )
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Exercise", "Foundation", "Walk 5 min"],
+        ["goal", "micro", "add", "Walk 5 min", "--goal", "Exercise", "--phase", "Foundation"],
         env=env,
     )
 

--- a/tests/integration/test_tree_cmd.py
+++ b/tests/integration/test_tree_cmd.py
@@ -32,7 +32,16 @@ def test_tree_displays_hierarchy(tmp_path) -> None:
     runner.invoke(cli, ["goal", "phase", "add", "Exercise", "Base"], env=env)
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Walk", "--goal", "Exercise", "--phase", "Base"],
+        [
+            "goal",
+            "micro",
+            "add",
+            "Walk",
+            "--goal",
+            "Exercise",
+            "--phase",
+            "Base",
+        ],
         env=env,
     )
 

--- a/tests/integration/test_tree_cmd.py
+++ b/tests/integration/test_tree_cmd.py
@@ -32,7 +32,7 @@ def test_tree_displays_hierarchy(tmp_path) -> None:
     runner.invoke(cli, ["goal", "phase", "add", "Exercise", "Base"], env=env)
     runner.invoke(
         cli,
-        ["goal", "micro", "add", "Exercise", "Base", "Walk"],
+        ["goal", "micro", "add", "Walk", "--goal", "Exercise", "--phase", "Base"],
         env=env,
     )
 

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -159,8 +159,12 @@ def test_micro_add_missing_phase(
     JSONStore(path=tmp_path / "data.json").save([GoalArea(name="G")])
     runner = CliRunner()
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
-    res = runner.invoke(cli, ["goal", "micro", "add", "G", "P", "M"], env=env)
-    assert "Goal or phase not found" in res.output
+    res = runner.invoke(
+        cli,
+        ["goal", "micro", "add", "M", "--goal", "G", "--phase", "P"],
+        env=env,
+    )
+    assert "Phase 'P' not found" in res.output
 
 
 def test_micro_cancel_missing(
@@ -178,10 +182,10 @@ def test_micro_cancel_missing(
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
     res = runner.invoke(
         cli,
-        ["goal", "micro", "cancel", "G", "P", "M"],
+        ["goal", "micro", "rm", "M", "--goal", "G", "--phase", "P"],
         env=env,
     )
-    assert "Micro-habit not found" in res.output
+    assert "Micro-habit 'M' not found" in res.output
 
 
 def test_micro_cancel_no_phase(
@@ -198,10 +202,10 @@ def test_micro_cancel_no_phase(
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
     res = runner.invoke(
         cli,
-        ["goal", "micro", "cancel", "G", "P", "M"],
+        ["goal", "micro", "rm", "M", "--goal", "G", "--phase", "P"],
         env=env,
     )
-    assert "Goal or phase not found" in res.output
+    assert "Phase 'P' not found" in res.output
 
 
 def test_checkin_errors(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,3 @@
-import pytest
 from loopbloom.core.models import GoalArea, MicroGoal
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,11 @@
+import pytest
+from loopbloom.core.models import GoalArea, MicroGoal
+
+
+def test_goal_with_direct_microgoal_roundtrip() -> None:
+    """Ensure a goal with a direct micro-goal survives a dump/load cycle."""
+    mg = MicroGoal(name="Read one page")
+    ga = GoalArea(name="Reading", micro_goals=[mg])
+    dumped = ga.model_dump()
+    reloaded = GoalArea.model_validate(dumped)
+    assert reloaded.micro_goals[0].name == "Read one page"


### PR DESCRIPTION
## Summary
- allow direct micro-goals on `GoalArea`
- refactor micro CLI subcommands to use options
- update tree, checkin and summary commands for new model
- add integration test covering direct goal-level micro goals
- update affected tests and add a new model test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2a8c9b208322881050fbdbcfddfd