### PR TITLE
Add phase removal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ loopbloom help                         # global help
 
 GOALS & MICRO-HABITS
   loopbloom goal  list|add|edit|rm                # manage goal areas
-  loopbloom phase list|add|edit|rm                # optional phases
+  loopbloom goal phase add|rm                    # manage phases
   loopbloom micro list|add|edit|rm|start|cancel   # micro-habit operations
   loopbloom tree                         # show goal hierarchy
 

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -125,6 +125,58 @@ def phase_add(
     click.echo(f"[green]Added phase '{phase_name}' to {goal_name}")
 
 
+@phase.command(name="rm")
+@click.argument("goal_name", required=False)
+@click.argument("phase_name", required=False)
+@click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
+@with_goals
+def phase_rm(
+    ctx: click.Context,
+    goal_name: Optional[str],
+    phase_name: Optional[str],
+    yes: bool,
+    goals: List[GoalArea],
+) -> None:
+    """Remove a phase from a goal."""
+    if goal_name is None:
+        names = [g.name for g in goals]
+        if not names:
+            click.echo("[red]No goals – use `loopbloom goal add`.")
+            return
+        click.echo("Select goal:")
+        goal_name = choose_from(names, "Enter number")
+        if goal_name is None:
+            return
+
+    g = _find_goal(goals, goal_name)
+    if not g:
+        goal_not_found(goal_name, [x.name for x in goals])
+        return
+
+    if phase_name is None:
+        options = [p.name for p in g.phases]
+        if not options:
+            click.echo("[red]No phases found for this goal.")
+            return
+        click.echo("Select phase to delete:")
+        phase_name = choose_from(options, "Enter number")
+        if phase_name is None:
+            return
+
+    p = _find_phase(g, phase_name)
+    if not p:
+        click.echo("[red]Phase not found.")
+        return
+
+    if not yes and not click.confirm(
+        f"Delete phase '{phase_name}' from {goal_name}?",
+        default=False,
+    ):
+        return
+    g.phases.remove(p)
+    click.echo(f"[green]Deleted phase '{phase_name}' from {goal_name}")
+
+
 # Micro commands
 @goal.group(name="micro", help="Micro-habit commands.")
 def micro() -> None:

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -175,7 +175,11 @@ def test_phase_rm_yes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     store.save([GoalArea(name="G", phases=[Phase(name="P")])])
     runner = CliRunner()
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
-    res = runner.invoke(cli, ["goal", "phase", "rm", "G", "P", "--yes"], env=env)
+    res = runner.invoke(
+        cli,
+        ["goal", "phase", "rm", "G", "P", "--yes"],
+        env=env,
+    )
     assert "Deleted phase" in res.output
 
 

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -148,6 +148,37 @@ def test_goal_rm_yes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Deleted goal" in res.output
 
 
+def test_phase_rm_requires_confirm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deleting a phase without ``--yes`` asks for confirmation."""
+    from loopbloom.core.models import GoalArea, Phase
+    from loopbloom.storage.json_store import JSONStore
+
+    cli = _reload_cli(tmp_path, monkeypatch)
+    store = JSONStore(path=tmp_path / "data.json")
+    store.save([GoalArea(name="G", phases=[Phase(name="P")])])
+    monkeypatch.setattr(click, "confirm", lambda *a, **k: False)
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(cli, ["goal", "phase", "rm", "G", "P"], env=env)
+    assert "Deleted" not in res.output
+
+
+def test_phase_rm_yes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove a phase immediately with ``--yes``."""
+    from loopbloom.core.models import GoalArea, Phase
+    from loopbloom.storage.json_store import JSONStore
+
+    cli = _reload_cli(tmp_path, monkeypatch)
+    store = JSONStore(path=tmp_path / "data.json")
+    store.save([GoalArea(name="G", phases=[Phase(name="P")])])
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(cli, ["goal", "phase", "rm", "G", "P", "--yes"], env=env)
+    assert "Deleted phase" in res.output
+
+
 def test_micro_add_missing_phase(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add goal phase rm command with optional confirmation
- document phase rm command in README cheat sheet
- test phase removal via CLI
- cover edge cases for phase_rm in additional coverage tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2a9ce4148322afc14ccda64382e7