### PR TITLE
Store data under config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ CLI shortcut: `loopbloom config set storage sqlite`.
 
 | Backend                                                              | Path                     | Use-case                             |
 | -------------------------------------------------------------------- | ------------------------ | ------------------------------------ |
-| **JSON** (default)                                                   | `~/.loopbloom/data.json` | Simple, git-friendly.                |
-| **SQLite**                                                           | `~/.loopbloom/data.db`   | Large histories, multi-tool queries. |
+| **JSON** (default)                                                   | `~/.config/loopbloom/data.json` | Simple, git-friendly.                |
+| **SQLite**                                                           | `~/.config/loopbloom/data.db`   | Large histories, multi-tool queries. |
 | Custom stores implement the `Storage` protocol in `storage/base.py`. |                          |                                      |
 
 <a id="coping"></a>

--- a/loopbloom/core/config.py
+++ b/loopbloom/core/config.py
@@ -10,8 +10,9 @@ import tomli_w
 import tomllib
 
 XDG_CONFIG_HOME = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config"))
-CONFIG_PATH = XDG_CONFIG_HOME / "loopbloom" / "config.toml"
-CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+APP_DIR = XDG_CONFIG_HOME / "loopbloom"
+APP_DIR.mkdir(parents=True, exist_ok=True)
+CONFIG_PATH = APP_DIR / "config.toml"
 
 DEFAULTS: Dict[str, Any] = {
     "storage": "json",  # json | sqlite

--- a/loopbloom/storage/json_store.py
+++ b/loopbloom/storage/json_store.py
@@ -11,10 +11,11 @@ from typing import ContextManager, List
 from pydantic.json import pydantic_encoder
 
 from loopbloom.core.models import GoalArea
+from loopbloom.core.config import APP_DIR
 from loopbloom.storage.base import Storage, StorageError
 
 DEFAULT_PATH = Path(
-    os.getenv("LOOPBLOOM_DATA_PATH", Path.home() / ".loopbloom" / "data.json")
+    os.getenv("LOOPBLOOM_DATA_PATH", APP_DIR / "data.json")
 )
 DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
 

--- a/loopbloom/storage/sqlite_store.py
+++ b/loopbloom/storage/sqlite_store.py
@@ -23,9 +23,10 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from loopbloom.core.models import GoalArea
 from loopbloom.storage.base import Storage, StorageError
+from loopbloom.core.config import APP_DIR
 
 DEFAULT_PATH = Path(
-    os.getenv("LOOPBLOOM_SQLITE_PATH", Path.home() / ".loopbloom" / "data.db")
+    os.getenv("LOOPBLOOM_SQLITE_PATH", APP_DIR / "data.db")
 )
 DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- centralize all data in the XDG config location
- reference new paths in documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2fe7bff8832290dd950b84206849