### PR TITLE
Add phase auto-create when adding micro

### DIFF
--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -196,7 +196,7 @@ def micro() -> None:
     "--phase",
     "phase_name",
     default=None,
-    help="Add to a specific phase.",
+    help="Add to a specific phase (created if needed).",
 )
 @with_goals
 def micro_add(
@@ -206,7 +206,11 @@ def micro_add(
     phase_name: Optional[str],
     goals: List[GoalArea],
 ) -> None:
-    """Add a new micro-habit, either to a goal or a phase."""
+    """Add a new micro-habit to a goal or phase.
+
+    If ``phase_name`` is provided but doesn't exist, a new phase will be
+    created automatically.
+    """
     g = _find_goal(goals, goal_name)
     if not g:
         goal_not_found(goal_name, [x.name for x in goals])
@@ -219,10 +223,11 @@ def micro_add(
 
     p = _find_phase(g, phase_name)
     if not p:
+        p = Phase(name=phase_name.strip())
+        g.phases.append(p)
         click.echo(
-            f"[red]Phase '{phase_name}' not found in goal '{goal_name}'."
+            f"[yellow]Created phase '{phase_name}' under goal '{goal_name}'."
         )
-        return
     p.micro_goals.append(MicroGoal(name=name.strip()))
     click.echo(
         f"[green]Added micro-habit '{name}' to {goal_name}/{phase_name}"

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -174,3 +174,47 @@ def test_phase_rm(tmp_path) -> None:
 
     data = json.loads(data_file.read_text())
     assert data[0]["phases"] == []
+
+
+def test_micro_add_creates_phase(tmp_path) -> None:
+    """Adding a micro-habit with a new phase creates that phase."""
+    runner = CliRunner()
+    data_file = tmp_path / "data.json"
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
+
+    import importlib
+
+    import loopbloom.cli as cli_mod
+    import loopbloom.cli.goal as goal_mod
+    import loopbloom.storage.json_store as js_mod
+    from loopbloom import __main__ as main
+
+    importlib.reload(js_mod)
+    importlib.reload(cli_mod)
+    importlib.reload(goal_mod)
+    importlib.reload(main)
+    cli = main.cli
+
+    runner.invoke(cli, ["goal", "add", "Exercise"], env=env)
+
+    res = runner.invoke(
+        cli,
+        [
+            "goal",
+            "micro",
+            "add",
+            "Walk",
+            "--goal",
+            "Exercise",
+            "--phase",
+            "Base",
+        ],
+        env=env,
+    )
+    assert "Added micro-habit" in res.output
+
+    data = json.loads(data_file.read_text())
+    assert len(data[0]["phases"]) == 1
+    assert data[0]["phases"][0]["micro_goals"][0]["name"] == "Walk"


### PR DESCRIPTION
## Summary
- allow adding a micro-habit to a non-existent phase
- test creating a phase implicitly when adding a micro-habit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684b31eee0d0832287fb6420737f1b27