### PR TITLE
Refactor active micro-goal lookup

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -47,16 +47,7 @@ def checkin(
         goal_not_found(goal_name, [g.name for g in goals])
         return
     # Find the active micro-goal
-    mg = None
-    # First, search in phases
-    for ph in goal.phases:
-        mg = next((m for m in ph.micro_goals if m.status == "active"), None)
-        if mg:
-            break
-
-    # If not found, search in direct micro-goals
-    if mg is None:
-        mg = next((m for m in goal.micro_goals if m.status == "active"), None)
+    mg = goal.get_active_micro_goal()
 
     if mg is None:
         click.echo("[red]No active micro-goal found for this goal.")

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -72,20 +72,8 @@ def _overview(goals: List[GoalArea]) -> None:
         else:
             ratio = "\u2013"
 
-        # Update logic to find the active micro-goal
-        active = None
-        for ph in g.phases:
-            active = next(
-                (m for m in ph.micro_goals if m.status == "active"),
-                None,
-            )
-            if active:
-                break
-        if active is None:
-            active = next(
-                (m for m in g.micro_goals if m.status == "active"),
-                None,
-            )
+        # Find the active micro-goal
+        active = g.get_active_micro_goal()
         flag = "Advance?" if active and should_advance(active) else "\u2014"
         table.add_row(g.name, ratio, flag)
     console.print(table)
@@ -98,13 +86,7 @@ def _detail_view(goal_name: str, goals: List[GoalArea]) -> None:
         goal_not_found(goal_name, [x.name for x in goals])
         return
     # Update logic to find the active micro-goal
-    mg = None
-    for ph in g.phases:
-        mg = next((m for m in ph.micro_goals if m.status == "active"), None)
-        if mg:
-            break
-    if mg is None:
-        mg = next((m for m in g.micro_goals if m.status == "active"), None)
+    mg = g.get_active_micro_goal()
 
     if mg is None:
         click.echo("[yellow]No active micro-goal.")
@@ -120,9 +102,7 @@ def _detail_view(goal_name: str, goals: List[GoalArea]) -> None:
         progress = Group(bar, f" {successes}/{total}")
     else:
         progress = "\u2013"
-    console.print(
-        f"Success rate last {window}\u00a0days: ", progress, f"  {flag}"
-    )
+    console.print(f"Success rate last {window}\u00a0days: ", progress, f"  {flag}")
     # notify if eligible for advancement
     from loopbloom.services import notifier
 

--- a/loopbloom/core/models.py
+++ b/loopbloom/core/models.py
@@ -58,3 +58,11 @@ class GoalArea(BaseModel):
     phases: list[Phase] = Field(default_factory=list)
     micro_goals: list[MicroGoal] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    def get_active_micro_goal(self) -> MicroGoal | None:
+        """Find the active micro-goal within phases or direct goals."""
+        for ph in self.phases:
+            mg = next((m for m in ph.micro_goals if m.status == "active"), None)
+            if mg:
+                return mg
+        return next((m for m in self.micro_goals if m.status == "active"), None)

--- a/loopbloom/tests/unit/test_models.py
+++ b/loopbloom/tests/unit/test_models.py
@@ -39,3 +39,25 @@ def test_microgoal_name_trimmed() -> None:
     """Whitespace is stripped from names."""
     mg = MicroGoal(name="  Walk  ")
     assert mg.name == "Walk"
+
+
+def test_goalarea_get_active_micro_goal() -> None:
+    """Return the active micro-goal from phases or direct list."""
+    active = MicroGoal(name="Active")
+    phase = Phase(
+        name="P",
+        micro_goals=[MicroGoal(name="Done", status=Status.complete), active],
+    )
+    ga = GoalArea(
+        name="G",
+        phases=[phase],
+        micro_goals=[MicroGoal(name="Direct", status=Status.complete)],
+    )
+    assert ga.get_active_micro_goal() is active
+
+    # No active in phases; fall back to direct micro-goals
+    for mg in phase.micro_goals:
+        mg.status = Status.complete
+    direct_active = MicroGoal(name="Direct Active")
+    ga.micro_goals.append(direct_active)
+    assert ga.get_active_micro_goal() is direct_active


### PR DESCRIPTION
## Summary
- add `GoalArea.get_active_micro_goal` helper
- use new helper in `checkin` and `summary` commands
- test the helper method

## Testing
- `flake8`
- `mypy loopbloom`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b634ce6b0832288577a06d6248798