### PR TITLE
Add micro goal status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ loopbloom help                         # global help
 GOALS & MICRO-HABITS
   loopbloom goal  list|add|edit|rm                # manage goal areas
   loopbloom goal phase add|rm                    # manage phases
-  loopbloom micro list|add|edit|rm|start|cancel   # micro-habit operations
+  loopbloom micro list|add|edit|rm|complete|cancel   # micro-habit operations
   loopbloom tree                         # show goal hierarchy
 
 CHECK-INS & FEEDBACK

--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -10,8 +10,9 @@ from loopbloom.cli.config import config  # NEW
 from loopbloom.cli.cope import cope  # NEW
 from loopbloom.cli.export import export  # NEW
 from loopbloom.cli.goal import goal
-from loopbloom.cli.tree import tree
+from loopbloom.cli.micro import micro
 from loopbloom.cli.summary import summary
+from loopbloom.cli.tree import tree
 
 if TYPE_CHECKING:  # pragma: no cover - hints for mypy
     pass
@@ -31,6 +32,7 @@ cli.add_command(cope)
 cli.add_command(config)
 cli.add_command(export)
 cli.add_command(tree)
+cli.add_command(micro)
 
 if __name__ == "__main__":
     cli()

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -16,7 +16,10 @@ def _find_goal(goals: List[GoalArea], name: str) -> Optional[GoalArea]:
 
 def _find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
     """Return phase from ``goal`` matching ``name`` if found."""
-    return next((p for p in goal.phases if p.name.lower() == name.lower()), None)
+    return next(
+        (p for p in goal.phases if p.name.lower() == name.lower()),
+        None,
+    )
 
 
 @click.group(name="micro", help="Micro-habit operations.")

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -1,0 +1,121 @@
+"""CLI commands for micro-habit lifecycle management."""
+
+from typing import List, Optional
+
+import click
+
+from loopbloom.cli import with_goals
+from loopbloom.cli.utils import goal_not_found
+from loopbloom.core.models import GoalArea, MicroGoal, Phase, Status
+
+
+def _find_goal(goals: List[GoalArea], name: str) -> Optional[GoalArea]:
+    """Return matching goal if present."""
+    return next((g for g in goals if g.name.lower() == name.lower()), None)
+
+
+def _find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
+    """Return phase from ``goal`` matching ``name`` if found."""
+    return next((p for p in goal.phases if p.name.lower() == name.lower()), None)
+
+
+@click.group(name="micro", help="Micro-habit operations.")
+def micro() -> None:
+    """Top-level micro-habit commands."""
+    pass
+
+
+@micro.command(name="complete")
+@click.argument("name")
+@click.option(
+    "--goal",
+    "goal_name",
+    required=True,
+    help="Goal containing this micro-habit.",
+)
+@click.option(
+    "--phase",
+    "phase_name",
+    default=None,
+    help="Phase containing this micro-habit.",
+)
+@with_goals
+def micro_complete(
+    ctx: click.Context,
+    name: str,
+    goal_name: str,
+    phase_name: Optional[str],
+    goals: List[GoalArea],
+) -> None:
+    """Mark a micro-habit as complete."""
+    g = _find_goal(goals, goal_name)
+    if not g:
+        goal_not_found(goal_name, [x.name for x in goals])
+        return
+
+    target_list: List[MicroGoal]
+    if phase_name:
+        p = _find_phase(g, phase_name)
+        if not p:
+            click.echo(f"[red]Phase '{phase_name}' not found.")
+            return
+        target_list = p.micro_goals
+    else:
+        target_list = g.micro_goals
+
+    mg = next((m for m in target_list if m.name.lower() == name.lower()), None)
+    if not mg:
+        loc = f"phase '{phase_name}'" if phase_name else f"goal '{goal_name}'"
+        click.echo(f"[red]Micro-habit '{name}' not found in {loc}.")
+        return
+
+    mg.status = Status.complete
+    click.echo(f"[green]Marked micro-habit '{name}' as complete.")
+
+
+@micro.command(name="cancel")
+@click.argument("name")
+@click.option(
+    "--goal",
+    "goal_name",
+    required=True,
+    help="Goal containing this micro-habit.",
+)
+@click.option(
+    "--phase",
+    "phase_name",
+    default=None,
+    help="Phase containing this micro-habit.",
+)
+@with_goals
+def micro_cancel(
+    ctx: click.Context,
+    name: str,
+    goal_name: str,
+    phase_name: Optional[str],
+    goals: List[GoalArea],
+) -> None:
+    """Cancel a micro-habit without deleting it."""
+    g = _find_goal(goals, goal_name)
+    if not g:
+        goal_not_found(goal_name, [x.name for x in goals])
+        return
+
+    target_list: List[MicroGoal]
+    if phase_name:
+        p = _find_phase(g, phase_name)
+        if not p:
+            click.echo(f"[red]Phase '{phase_name}' not found.")
+            return
+        target_list = p.micro_goals
+    else:
+        target_list = g.micro_goals
+
+    mg = next((m for m in target_list if m.name.lower() == name.lower()), None)
+    if not mg:
+        loc = f"phase '{phase_name}'" if phase_name else f"goal '{goal_name}'"
+        click.echo(f"[red]Micro-habit '{name}' not found in {loc}.")
+        return
+
+    mg.status = Status.cancelled
+    click.echo(f"[green]Cancelled micro-habit '{name}'.")

--- a/tests/unit/test_micro_cli.py
+++ b/tests/unit/test_micro_cli.py
@@ -26,7 +26,10 @@ def _reload_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return main.cli
 
 
-def test_micro_complete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_micro_complete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Marking a micro-habit complete updates its status."""
     from loopbloom.core.models import GoalArea, MicroGoal
     from loopbloom.storage.json_store import JSONStore

--- a/tests/unit/test_micro_cli.py
+++ b/tests/unit/test_micro_cli.py
@@ -1,0 +1,93 @@
+"""Unit tests for micro CLI commands."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+def _reload_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Reload CLI modules with custom data path."""
+    import loopbloom.cli as cli_mod
+    import loopbloom.cli.goal as goal_mod
+    import loopbloom.cli.micro as micro_mod
+    import loopbloom.storage.json_store as js_mod
+    from loopbloom import __main__ as main
+
+    monkeypatch.setenv("LOOPBLOOM_DATA_PATH", str(tmp_path / "data.json"))
+    importlib.reload(js_mod)
+    importlib.reload(cli_mod)
+    importlib.reload(goal_mod)
+    importlib.reload(micro_mod)
+    importlib.reload(main)
+    return main.cli
+
+
+def test_micro_complete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Marking a micro-habit complete updates its status."""
+    from loopbloom.core.models import GoalArea, MicroGoal
+    from loopbloom.storage.json_store import JSONStore
+
+    cli = _reload_cli(tmp_path, monkeypatch)
+    store = JSONStore(path=tmp_path / "data.json")
+    store.save([GoalArea(name="G", micro_goals=[MicroGoal(name="M")])])
+
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(
+        cli,
+        ["micro", "complete", "M", "--goal", "G"],
+        env=env,
+    )
+    assert "complete" in res.output
+    data = store.load()
+    assert data[0].micro_goals[0].status == "complete"
+
+
+def test_micro_cancel_phase_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing phase triggers an error message."""
+    from loopbloom.core.models import GoalArea
+    from loopbloom.storage.json_store import JSONStore
+
+    cli = _reload_cli(tmp_path, monkeypatch)
+    JSONStore(path=tmp_path / "data.json").save([GoalArea(name="G")])
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(
+        cli,
+        [
+            "micro",
+            "cancel",
+            "M",
+            "--goal",
+            "G",
+            "--phase",
+            "P",
+        ],
+        env=env,
+    )
+    assert "Phase 'P' not found" in res.output
+
+
+def test_micro_complete_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Completing a nonexistent micro-habit warns the user."""
+    from loopbloom.core.models import GoalArea
+    from loopbloom.storage.json_store import JSONStore
+
+    cli = _reload_cli(tmp_path, monkeypatch)
+    JSONStore(path=tmp_path / "data.json").save([GoalArea(name="G")])
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(
+        cli,
+        ["micro", "complete", "M", "--goal", "G"],
+        env=env,
+    )
+    assert "Micro-habit 'M' not found" in res.output


### PR DESCRIPTION
## Summary
- add a new `micro` command group with `complete` and `cancel`
- register the new group in the CLI entrypoint
- document new commands in README
- test micro status commands

## Testing
- `ruff check loopbloom/__main__.py loopbloom/cli/micro.py tests/unit/test_micro_cli.py`
- `black loopbloom/__main__.py loopbloom/cli/micro.py tests/unit/test_micro_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7e2c3c7883229b6839d13f7c701c