### PR TITLE
Use click context for store

### DIFF
--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -2,6 +2,9 @@
 
 from typing import TYPE_CHECKING, cast
 
+import os
+from pathlib import Path
+
 import click
 from click import Command
 
@@ -13,15 +16,32 @@ from loopbloom.cli.goal import goal
 from loopbloom.cli.micro import micro
 from loopbloom.cli.summary import summary
 from loopbloom.cli.tree import tree
+from loopbloom.core import config as cfg
+from loopbloom.storage.json_store import JSONStore, DEFAULT_PATH as JSON_DEFAULT_PATH
+from loopbloom.storage.sqlite_store import (
+    SQLiteStore,
+    DEFAULT_PATH as SQLITE_DEFAULT_PATH,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - hints for mypy
     pass
 
 
 @click.group()
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """LoopBloom – tiny habits, big momentum."""
-    pass
+    config = cfg.load()
+    storage_type = config.get("storage", "json")
+
+    if storage_type == "sqlite":
+        path = os.getenv("LOOPBLOOM_SQLITE_PATH", str(SQLITE_DEFAULT_PATH))
+        store = SQLiteStore(path)
+    else:
+        path = os.getenv("LOOPBLOOM_DATA_PATH", str(JSON_DEFAULT_PATH))
+        store = JSONStore(path)
+
+    ctx.obj = store
 
 
 # Register sub-commands

--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING, cast
 
 import os
-from pathlib import Path
 
 import click
 from click import Command
@@ -17,11 +16,15 @@ from loopbloom.cli.micro import micro
 from loopbloom.cli.summary import summary
 from loopbloom.cli.tree import tree
 from loopbloom.core import config as cfg
-from loopbloom.storage.json_store import JSONStore, DEFAULT_PATH as JSON_DEFAULT_PATH
+from loopbloom.storage.json_store import (
+    JSONStore,
+    DEFAULT_PATH as JSON_DEFAULT_PATH,
+)
 from loopbloom.storage.sqlite_store import (
     SQLiteStore,
     DEFAULT_PATH as SQLITE_DEFAULT_PATH,
 )
+from loopbloom.storage.base import Storage
 
 if TYPE_CHECKING:  # pragma: no cover - hints for mypy
     pass
@@ -34,6 +37,7 @@ def cli(ctx: click.Context) -> None:
     config = cfg.load()
     storage_type = config.get("storage", "json")
 
+    store: Storage
     if storage_type == "sqlite":
         path = os.getenv("LOOPBLOOM_SQLITE_PATH", str(SQLITE_DEFAULT_PATH))
         store = SQLiteStore(path)

--- a/loopbloom/cli/__init__.py
+++ b/loopbloom/cli/__init__.py
@@ -1,12 +1,9 @@
 """CLI storage loader and saver for LoopBloom."""
 
 from functools import wraps
-from pathlib import Path  # noqa: F401
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 import click
-
-from loopbloom.core.models import GoalArea
 
 
 def with_goals(f: Callable[..., Any]) -> Callable[..., Any]:
@@ -14,7 +11,7 @@ def with_goals(f: Callable[..., Any]) -> Callable[..., Any]:
 
     @wraps(f)
     @click.pass_context
-    def wrapper(ctx: click.Context, *args: Any, **kwargs: Any) -> Any:
+    def wrapper(ctx: click.Context, /, *args: Any, **kwargs: Any) -> Any:
         store = ctx.obj
         goals = store.load()
         result = f(*args, goals=goals, **kwargs)

--- a/loopbloom/cli/__init__.py
+++ b/loopbloom/cli/__init__.py
@@ -6,33 +6,19 @@ from typing import Any, Callable, List
 
 import click
 
-from loopbloom.core import config as cfg
 from loopbloom.core.models import GoalArea
-from loopbloom.storage.json_store import JSONStore
-from loopbloom.storage.sqlite_store import SQLiteStore
-
-store_backend = cfg.load().get("storage", "json")
-STORE = SQLiteStore() if store_backend == "sqlite" else JSONStore()
-
-
-def load_goals() -> List[GoalArea]:
-    """Load and return all goal areas."""
-    return STORE.load()
-
-
-def save_goals(goals: List[GoalArea]) -> None:
-    """Persist goal areas to disk."""
-    STORE.save(goals)
 
 
 def with_goals(f: Callable[..., Any]) -> Callable[..., Any]:
-    """Load goals for ``f`` then save afterwards."""  # noqa: D401
+    """Loads goals from the store in ctx.obj, then saves after."""
 
     @wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        goals = load_goals()
+    @click.pass_context
+    def wrapper(ctx: click.Context, *args: Any, **kwargs: Any) -> Any:
+        store = ctx.obj
+        goals = store.load()
         result = f(*args, goals=goals, **kwargs)
-        save_goals(goals)
+        store.save(goals)
         return result
 
-    return click.pass_context(wrapper)
+    return wrapper

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -21,7 +21,6 @@ from loopbloom.core.talks import TalkPool
 @click.option("--note", default="", help="Optional note.")
 @with_goals
 def checkin(
-    ctx: click.Context,
     goal_name: Optional[str],
     success: bool,
     note: str,

--- a/loopbloom/cli/export.py
+++ b/loopbloom/cli/export.py
@@ -6,17 +6,16 @@ from typing import List
 
 import click
 
-from loopbloom.storage.json_store import JSONStore
-
-STORE = JSONStore()
+from loopbloom.storage.base import Storage
 
 
 @click.command(name="export", help="Export data to CSV or JSON.")
 @click.option("--fmt", type=click.Choice(["csv", "json"]), required=True)
 @click.option("--out", "out_path", type=click.Path(), required=True)
-def export(fmt: str, out_path: str) -> None:
+@click.pass_obj
+def export(store: Storage, fmt: str, out_path: str) -> None:
     """Write all goal history to OUT_PATH in format FMT."""
-    goals = STORE.load()
+    goals = store.load()
 
     if fmt == "json":
         with open(out_path, "w", encoding="utf-8") as fp:

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -32,7 +32,7 @@ def goal() -> None:
 @goal.command(name="add")
 @click.argument("name")
 @with_goals
-def goal_add(ctx: click.Context, name: str, goals: List[GoalArea]) -> None:
+def goal_add(name: str, goals: List[GoalArea]) -> None:
     """Add a new goal area."""
     if _find_goal(goals, name):
         click.echo("[yellow]Goal already exists.")
@@ -43,7 +43,7 @@ def goal_add(ctx: click.Context, name: str, goals: List[GoalArea]) -> None:
 
 @goal.command(name="list")
 @with_goals
-def goal_list(ctx: click.Context, goals: List[GoalArea]) -> None:
+def goal_list(goals: List[GoalArea]) -> None:
     """List all goal areas."""
     if not goals:
         click.echo("[italic]No goals – use `loopbloom goal add`.")
@@ -57,7 +57,6 @@ def goal_list(ctx: click.Context, goals: List[GoalArea]) -> None:
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
 @with_goals
 def goal_rm(
-    ctx: click.Context,
     name: Optional[str],
     yes: bool,
     goals: List[GoalArea],
@@ -105,7 +104,6 @@ def phase() -> None:
 @click.argument("phase_name")
 @with_goals
 def phase_add(
-    ctx: click.Context,
     goal_name: Optional[str],
     phase_name: str,
     goals: List[GoalArea],
@@ -145,7 +143,6 @@ def phase_add(
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
 @with_goals
 def phase_rm(
-    ctx: click.Context,
     goal_name: Optional[str],
     phase_name: Optional[str],
     yes: bool,
@@ -228,7 +225,6 @@ def micro() -> None:
 )
 @with_goals
 def micro_add(
-    ctx: click.Context,
     name: str,
     goal_name: str,
     phase_name: Optional[str],
@@ -279,7 +275,6 @@ def micro_add(
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt.")
 @with_goals
 def micro_rm(
-    ctx: click.Context,
     name: str,
     goal_name: str,
     phase_name: Optional[str],

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -44,7 +44,6 @@ def micro() -> None:
 )
 @with_goals
 def micro_complete(
-    ctx: click.Context,
     name: str,
     goal_name: str,
     phase_name: Optional[str],
@@ -92,7 +91,6 @@ def micro_complete(
 )
 @with_goals
 def micro_cancel(
-    ctx: click.Context,
     name: str,
     goal_name: str,
     phase_name: Optional[str],

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -32,7 +32,7 @@ WINDOW_DEFAULT = 14  # days
     help="Show detail for one goal.",
 )
 @with_goals
-def summary(ctx, goal_name: str | None, goals: List[GoalArea]):  # type: ignore
+def summary(goal_name: str | None, goals: List[GoalArea]):  # type: ignore
     """Display a progress overview or detail view for a specific goal."""
     if goal_name:
         _detail_view(goal_name, goals)

--- a/loopbloom/cli/tree.py
+++ b/loopbloom/cli/tree.py
@@ -14,7 +14,7 @@ console = Console()
 
 @click.command(name="tree", help="Show goal hierarchy as a tree.")
 @with_goals
-def tree(ctx: click.Context, goals: List[GoalArea]) -> None:
+def tree(goals: List[GoalArea]) -> None:
     """Display all goals, phases, and micro-habits in a tree view."""
     root = Tree("\U0001F333 LoopBloom Goals")
     for g in goals:

--- a/tests/integration/test_direct_microgoals.py
+++ b/tests/integration/test_direct_microgoals.py
@@ -1,26 +1,16 @@
 import json
 import os
-import importlib
 from click.testing import CliRunner
 
 
 def _reload_cli_modules():
-    """Helper to reload modules to pick up changes."""
+    """Return CLI instance."""
     import sys
     from pathlib import Path
     root = Path(__file__).resolve().parents[2]
     if str(root) not in sys.path:
         sys.path.insert(0, str(root))
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.cli.tree as tree_mod
-    import loopbloom.cli as cli_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(tree_mod)
-    importlib.reload(main)
     return main.cli
 
 
@@ -30,7 +20,7 @@ def test_direct_microgoal_workflow(tmp_path):
     data_file = tmp_path / "data.json"
     env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
 
-    # Ensure env var is set for reloads
+    # Ensure env var is set for CLI invocation
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
     cli = _reload_cli_modules()
 

--- a/tests/integration/test_export_and_config_cmds.py
+++ b/tests/integration/test_export_and_config_cmds.py
@@ -24,19 +24,11 @@ def test_export_json_and_csv(tmp_path):
     runner = CliRunner()
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
 
-    import importlib
     import os
 
-    import loopbloom.__main__ as main
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.export as export_mod
-    import loopbloom.storage.json_store as js_mod
+    from loopbloom import __main__ as main
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(tmp_path / "data.json")
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(export_mod)
-    importlib.reload(main)
 
     runner.invoke(main.cli, ["goal", "add", "Sleep"], env=env)
     runner.invoke(main.cli, ["goal", "phase", "add", "Sleep", "Base"], env=env)

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -144,8 +144,6 @@ def test_micro_add_creates_phase(tmp_path) -> None:
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
-    import importlib
-
     from loopbloom import __main__ as main
     cli = main.cli
 

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -18,17 +18,7 @@ def test_goal_phase_micro_crud(tmp_path):
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
-    import importlib
-
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(main)
     cli = main.cli
 
     # Add a goal
@@ -95,17 +85,7 @@ def test_goal_rm_missing(tmp_path) -> None:
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
-    import importlib
-
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(main)
     cli = main.cli
 
     res = runner.invoke(cli, ["goal", "rm", "Ghost", "--yes"], env=env)
@@ -120,17 +100,7 @@ def test_phase_add_missing_goal(tmp_path) -> None:
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
-    import importlib
-
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(main)
     cli = main.cli
 
     res = runner.invoke(
@@ -149,17 +119,7 @@ def test_phase_rm(tmp_path) -> None:
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
-    import importlib
-
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(main)
     cli = main.cli
 
     runner.invoke(cli, ["goal", "add", "Exercise"], env=env)
@@ -186,15 +146,7 @@ def test_micro_add_creates_phase(tmp_path) -> None:
 
     import importlib
 
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(main)
     cli = main.cli
 
     runner.invoke(cli, ["goal", "add", "Exercise"], env=env)

--- a/tests/integration/test_interactive_selection.py
+++ b/tests/integration/test_interactive_selection.py
@@ -1,6 +1,5 @@
 """Tests for interactive selection menus."""
 
-import importlib
 import json
 import os
 

--- a/tests/integration/test_interactive_selection.py
+++ b/tests/integration/test_interactive_selection.py
@@ -15,16 +15,6 @@ def test_checkin_prompts_for_goal(tmp_path) -> None:
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(tmp_path / "data.json")
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.checkin as checkin_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(checkin_mod)
-    importlib.reload(main)
     cli = main.cli
 
     # setup

--- a/tests/integration/test_notify_and_sqlite.py
+++ b/tests/integration/test_notify_and_sqlite.py
@@ -19,13 +19,8 @@ def test_switch_to_sqlite_and_notify(tmp_path, monkeypatch):
     importlib.reload(cfg_mod)
     runner.invoke(cli, ["config", "set", "storage", "sqlite"])
     import loopbloom.__main__ as main
-    import loopbloom.cli as cli_mod
-    import loopbloom.storage.sqlite_store as sql_mod
 
     importlib.reload(cfg_mod)
-    importlib.reload(sql_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(main)
     new_cli = main.cli
 
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "dummy.json")}

--- a/tests/integration/test_progression_summary.py
+++ b/tests/integration/test_progression_summary.py
@@ -21,20 +21,12 @@ def test_summary_shows_advance_prompt(tmp_path):
     runner = CliRunner()
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
 
-    import importlib
     import os
 
     os.environ["LOOPBLOOM_DATA_PATH"] = env["LOOPBLOOM_DATA_PATH"]
 
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
 
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(main)
     cli = main.cli
 
     # Setup

--- a/tests/integration/test_tree_cmd.py
+++ b/tests/integration/test_tree_cmd.py
@@ -1,6 +1,5 @@
 """Integration tests for the tree CLI command."""
 
-import importlib
 import os
 
 from click.testing import CliRunner

--- a/tests/integration/test_tree_cmd.py
+++ b/tests/integration/test_tree_cmd.py
@@ -13,19 +13,7 @@ def test_tree_displays_hierarchy(tmp_path) -> None:
     env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
-
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.cli.tree as tree_mod
-    import loopbloom.storage.json_store as js_mod
     from loopbloom import __main__ as main
-
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(tree_mod)
-    importlib.reload(main)
-
     cli = main.cli
 
     runner.invoke(cli, ["goal", "add", "Exercise"], env=env)

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -89,15 +89,10 @@ def test_step_validation_error():
 
 
 def _reload_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Reload CLI modules with data path at ``tmp_path``."""
-    import loopbloom.cli as cli_mod
-    import loopbloom.storage.json_store as js_mod
+    """Return CLI with data path at ``tmp_path``."""
     from loopbloom import __main__ as main
 
     monkeypatch.setenv("LOOPBLOOM_DATA_PATH", str(tmp_path / "data.json"))
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(main)
     return main.cli
 
 
@@ -362,9 +357,7 @@ def test_phase_add_interactive(
     recorded: list[str] = []
     monkeypatch.setattr(click, "echo", lambda m: recorded.append(m))
 
-    goal_mod.phase_add.callback.__wrapped__.__wrapped__(
-        None, None, "P", goals
-    )
+    goal_mod.phase_add.callback.__wrapped__(None, "P", goals)
 
     assert goals[0].phases[0].name == "P"
     assert any("Added phase 'P'" in m for m in recorded)

--- a/tests/unit/test_micro_cli.py
+++ b/tests/unit/test_micro_cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 from pathlib import Path
 
 import pytest
@@ -10,19 +9,10 @@ from click.testing import CliRunner
 
 
 def _reload_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Reload CLI modules with custom data path."""
-    import loopbloom.cli as cli_mod
-    import loopbloom.cli.goal as goal_mod
-    import loopbloom.cli.micro as micro_mod
-    import loopbloom.storage.json_store as js_mod
+    """Return CLI with data path set to ``tmp_path``."""
     from loopbloom import __main__ as main
 
     monkeypatch.setenv("LOOPBLOOM_DATA_PATH", str(tmp_path / "data.json"))
-    importlib.reload(js_mod)
-    importlib.reload(cli_mod)
-    importlib.reload(goal_mod)
-    importlib.reload(micro_mod)
-    importlib.reload(main)
     return main.cli
 
 


### PR DESCRIPTION
## Summary
- create storage instance in main and store in `ctx.obj`
- update `with_goals` decorator to read the store from context
- drop unnecessary context parameters in CLI commands
- access the store via context in the export command
- simplify tests now that reloading modules isn't required

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f312a6c648322b9ba67e760912364