### PR TITLE
Add report command with heatmap visualization

### DIFF
--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -1,8 +1,7 @@
 """LoopBloom CLI entry point."""
 
-from typing import TYPE_CHECKING, cast
-
 import os
+from typing import TYPE_CHECKING, cast
 
 import click
 from click import Command
@@ -13,18 +12,23 @@ from loopbloom.cli.cope import cope  # NEW
 from loopbloom.cli.export import export  # NEW
 from loopbloom.cli.goal import goal
 from loopbloom.cli.micro import micro
+from loopbloom.cli.report import report
 from loopbloom.cli.summary import summary
 from loopbloom.cli.tree import tree
 from loopbloom.core import config as cfg
+from loopbloom.storage.base import Storage
+from loopbloom.storage.json_store import (
+    DEFAULT_PATH as JSON_DEFAULT_PATH,
+)
 from loopbloom.storage.json_store import (
     JSONStore,
-    DEFAULT_PATH as JSON_DEFAULT_PATH,
+)
+from loopbloom.storage.sqlite_store import (
+    DEFAULT_PATH as SQLITE_DEFAULT_PATH,
 )
 from loopbloom.storage.sqlite_store import (
     SQLiteStore,
-    DEFAULT_PATH as SQLITE_DEFAULT_PATH,
 )
-from loopbloom.storage.base import Storage
 
 if TYPE_CHECKING:  # pragma: no cover - hints for mypy
     pass
@@ -52,6 +56,7 @@ def cli(ctx: click.Context) -> None:
 cli.add_command(goal)
 cli.add_command(cast(Command, checkin))  # type: ignore[redundant-cast]  # NEW
 cli.add_command(summary)  # NEW
+cli.add_command(report)
 cli.add_command(cope)
 cli.add_command(config)
 cli.add_command(export)

--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -1,0 +1,102 @@
+"""Advanced reports for LoopBloom."""
+
+from __future__ import annotations
+
+from calendar import Calendar, month_name
+from datetime import date
+from typing import Iterable, List
+
+import click
+from rich.console import Console, Group
+from rich.progress_bar import ProgressBar
+from rich.table import Table
+
+from loopbloom.cli import with_goals
+from loopbloom.core.models import GoalArea
+
+console = Console()
+
+
+@click.command(
+    name="report",
+    help="Show calendar heatmap or success bars for goals.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["calendar", "success"], case_sensitive=False),
+    default="calendar",
+    help="Report type to display.",
+)
+@with_goals
+def report(mode: str, goals: List[GoalArea]) -> None:  # type: ignore
+    """Display advanced reports based on ``mode``."""
+    if mode == "success":
+        _success_bars(goals)
+    else:
+        _calendar_heatmap(goals)
+
+
+def _gather_all_micro(goals: Iterable[GoalArea]):
+    """Yield all micro-goals from ``goals``."""
+    for g in goals:
+        for ph in g.phases:
+            for m in ph.micro_goals:
+                yield m
+        for m in g.micro_goals:
+            yield m
+
+
+def _calendar_heatmap(goals: List[GoalArea]) -> None:
+    """Print an ASCII calendar heatmap of the current month."""
+    today = date.today()
+    cal = Calendar()
+    # Build map of day -> (successes, total)
+    stats: dict[int, tuple[int, int]] = {}
+    for m in _gather_all_micro(goals):
+        for ci in m.checkins:
+            if ci.date.year == today.year and ci.date.month == today.month:
+                succ, tot = stats.get(ci.date.day, (0, 0))
+                if ci.success:
+                    succ += 1
+                tot += 1
+                stats[ci.date.day] = (succ, tot)
+
+    weeks = cal.monthdayscalendar(today.year, today.month)
+    title = f"LoopBloom Check-in Heatmap – {month_name[today.month]} {today.year}"
+    console.print(f"[bold]{title}[/bold]")
+    for week in weeks:
+        line = ""
+        for day in week:
+            if day == 0:
+                line += "   "
+                continue
+            succ, tot = stats.get(day, (0, 0))
+            char = "·"  # dot
+            if tot:
+                char = "░"  # light shade for skips
+                if succ:
+                    char = "▓"  # dark shade
+            line += f"{char} "
+        console.print(line.rstrip())
+
+
+def _success_bars(goals: List[GoalArea]) -> None:
+    """Show a bar chart of success rates per goal."""
+    table = Table(title="Success Rates per Goal")
+    table.add_column("Goal")
+    table.add_column("Rate")
+    for g in goals:
+        successes = 0
+        total = 0
+        for m in _gather_all_micro([g]):
+            for ci in m.checkins:
+                total += 1
+                if ci.success:
+                    successes += 1
+        if total:
+            bar = ProgressBar(total=total, completed=successes, width=20)
+            ratio = Group(bar, f" {successes}/{total}")
+        else:
+            ratio = "–"
+        table.add_row(g.name, ratio)
+    console.print(table)

--- a/tests/integration/test_report_cmd.py
+++ b/tests/integration/test_report_cmd.py
@@ -1,0 +1,20 @@
+"""Integration test for the report command."""
+
+from click.testing import CliRunner
+
+from loopbloom.__main__ import cli
+
+
+def test_report_command_outputs(tmp_path) -> None:  # noqa: D103
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    # Setup basic goal and micro-goal
+    runner.invoke(cli, ["goal", "add", "Health"], env=env)
+    runner.invoke(cli, ["micro", "add", "Walk", "--goal", "Health"], env=env)
+    runner.invoke(cli, ["checkin", "Health"], env=env)
+
+    res = runner.invoke(cli, ["report", "--mode", "success"], env=env)
+    assert "Health" in res.output
+    res2 = runner.invoke(cli, ["report", "--mode", "calendar"], env=env)
+    assert "Heatmap" in res2.output

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -1,0 +1,17 @@
+"""Tests for report CLI helpers."""
+
+from datetime import date
+
+from loopbloom.cli.report import _calendar_heatmap, _success_bars
+from loopbloom.core.models import Checkin, GoalArea, MicroGoal
+
+
+def test_report_helpers(capsys) -> None:  # noqa: D103
+    goal = GoalArea(name="G", micro_goals=[MicroGoal(name="M")])
+    goal.micro_goals[0].checkins.append(Checkin(date=date.today(), success=True))
+    _calendar_heatmap([goal])
+    out = capsys.readouterr().out
+    assert "LoopBloom Check-in Heatmap" in out
+    _success_bars([goal])
+    out2 = capsys.readouterr().out
+    assert "Success Rates per Goal" in out2


### PR DESCRIPTION
## Summary
- implement new `report` command for advanced reporting
- display calendar heatmap and success rate bars
- integrate command in CLI entrypoint
- add unit and integration tests

## Testing
- `ruff check loopbloom/__main__.py loopbloom/cli/report.py tests/unit/test_report_cli.py tests/integration/test_report_cmd.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850866379d88322b5c3fb0fbde5b3bd