### PR TITLE
Enable custom data path via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Settings live in `~/.config/loopbloom/config.toml` (XDG). Example:
 
 ```toml
 storage = "json"            # json | sqlite
+data_path = ""              # optional override for data file
 notify  = "terminal"        # terminal | desktop | none
 advance.threshold = 0.80    # float (0-1)
 advance.window    = 14       # days
@@ -181,6 +182,7 @@ CLI shortcut: `loopbloom config set storage sqlite`.
 | **SQLite**                                                           | `~/.config/loopbloom/data.db`   | Large histories, multi-tool queries. |
 | Custom stores implement the `Storage` protocol in `storage/base.py`. |                          |                                      |
 
+Set `data_path` in `config.toml` or use `LOOPBLOOM_DATA_PATH`/`LOOPBLOOM_SQLITE_PATH` to keep data elsewhere.
 <a id="coping"></a>
 
 ## 9  Coping Plans

--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -40,16 +40,24 @@ def cli(ctx: click.Context) -> None:
     """LoopBloom – tiny habits, big momentum."""
     config = cfg.load()
     storage_type = config.get("storage", "json")
+    cfg_path = str(config.get("data_path") or "")
 
     store: Storage
     if storage_type == "sqlite":
-        # Allow ``LOOPBLOOM_SQLITE_PATH`` to override the on-disk location.
-        path = os.getenv("LOOPBLOOM_SQLITE_PATH", str(SQLITE_DEFAULT_PATH))
+        # Environment variable overrides config which overrides the default.
+        path = (
+            os.getenv("LOOPBLOOM_SQLITE_PATH")
+            or cfg_path
+            or str(SQLITE_DEFAULT_PATH)
+        )
         store = SQLiteStore(path)
     else:
-        # Default to a JSON file if no storage override is set.
-        # ``LOOPBLOOM_DATA_PATH`` lets advanced users keep data elsewhere.
-        path = os.getenv("LOOPBLOOM_DATA_PATH", str(JSON_DEFAULT_PATH))
+        # ``LOOPBLOOM_DATA_PATH`` or config ``data_path`` may override.
+        path = (
+            os.getenv("LOOPBLOOM_DATA_PATH")
+            or cfg_path
+            or str(JSON_DEFAULT_PATH)
+        )
         store = JSONStore(path)
 
     # Expose the store instance to subcommands via Click's context object.

--- a/loopbloom/core/config.py
+++ b/loopbloom/core/config.py
@@ -28,6 +28,9 @@ DEFAULTS: Dict[str, Any] = {
     # Persistence back-end. 'json' keeps everything in a file while 'sqlite'
     # stores data in a lightweight database.
     "storage": "json",  # json | sqlite
+    # Optional path override for the selected storage back-end.
+    # When empty, defaults described in README are used.
+    "data_path": "",
     # How progress notifications are delivered.
     "notify": "terminal",  # terminal | desktop | none
     # Parameters for the auto-progression engine.

--- a/tests/integration/test_external_datapath.py
+++ b/tests/integration/test_external_datapath.py
@@ -1,0 +1,22 @@
+import importlib
+from click.testing import CliRunner
+
+
+def test_cli_respects_config_data_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("LOOPBLOOM_DATA_PATH", raising=False)
+    monkeypatch.delenv("LOOPBLOOM_SQLITE_PATH", raising=False)
+    import loopbloom.core.config as cfg_mod
+    importlib.reload(cfg_mod)
+
+    # Configure custom data path then reload the CLI to pick it up.
+    data_file = tmp_path / "external.json"
+    cfg_mod.save({"data_path": str(data_file)})
+
+    from loopbloom import __main__ as main
+    importlib.reload(main)
+
+    runner = CliRunner()
+    res = runner.invoke(main.cli, ["goal", "add", "Persist"], env={})
+    assert res.exit_code == 0
+    assert data_file.exists()


### PR DESCRIPTION
## Summary
- allow data_path override in config
- respect the setting in the CLI
- document external data path usage
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e6523dd08322872024867ae16fbf