### PR TITLE
Add goal & phase notes

### DIFF
--- a/loopbloom/core/models.py
+++ b/loopbloom/core/models.py
@@ -54,6 +54,7 @@ class Phase(BaseModel):
     # Unique ID to allow stable references even if names change.
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str
+    notes: str | None = None
     micro_goals: list[MicroGoal] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -64,6 +65,7 @@ class GoalArea(BaseModel):
     # Unique ID for this goal area.
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str
+    notes: str | None = None
     phases: list[Phase] = Field(default_factory=list)
     micro_goals: list[MicroGoal] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -165,3 +165,50 @@ def test_micro_add_creates_phase(tmp_path) -> None:
     data = json.loads(data_file.read_text())
     assert len(data[0]["phases"]) == 1
     assert data[0]["phases"][0]["micro_goals"][0]["name"] == "Walk"
+
+
+def test_goal_and_phase_notes(tmp_path) -> None:
+    """Notes can be added and viewed for goals and phases."""
+    runner = CliRunner()
+    data_file = tmp_path / "data.json"
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
+    from loopbloom import __main__ as main
+    cli = main.cli
+
+    # Goal notes
+    runner.invoke(
+        cli,
+        ["goal", "add", "Exercise", "--notes", "start"],
+        env=env,
+    )
+    res = runner.invoke(cli, ["goal", "notes", "Exercise"], env=env)
+    assert "start" in res.output
+    runner.invoke(cli, ["goal", "notes", "Exercise", "updated"], env=env)
+    res = runner.invoke(cli, ["goal", "notes", "Exercise"], env=env)
+    assert "updated" in res.output
+
+    # Phase notes
+    runner.invoke(
+        cli,
+        ["goal", "phase", "add", "Exercise", "Base", "--notes", "plan"],
+        env=env,
+    )
+    res = runner.invoke(
+        cli,
+        ["goal", "phase", "notes", "Exercise", "Base"],
+        env=env,
+    )
+    assert "plan" in res.output
+    runner.invoke(
+        cli,
+        ["goal", "phase", "notes", "Exercise", "Base", "do it"],
+        env=env,
+    )
+    res = runner.invoke(
+        cli,
+        ["goal", "phase", "notes", "Exercise", "Base"],
+        env=env,
+    )
+    assert "do it" in res.output

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -357,7 +357,7 @@ def test_phase_add_interactive(
     recorded: list[str] = []
     monkeypatch.setattr(click, "echo", lambda m: recorded.append(m))
 
-    goal_mod.phase_add.callback.__wrapped__(None, "P", goals)
+    goal_mod.phase_add.callback.__wrapped__(None, "P", "", goals)
 
     assert goals[0].phases[0].name == "P"
     assert any("Added phase 'P'" in m for m in recorded)


### PR DESCRIPTION
## Summary
- allow storing notes on `GoalArea` and `Phase`
- expose `--notes` flag on `goal add` and `goal phase add`
- new `goal notes` and `goal phase notes` commands
- display notes in `goal list`
- test coverage for note commands

## Testing
- `flake8`
- `mypy loopbloom`
- `pytest --cov=loopbloom --cov-fail-under=80 -q`

------
https://chatgpt.com/codex/tasks/task_e_68646b91b5248322bd93ca9803dda164