### PR TITLE
Add per-micro-goal advancement settings

### DIFF
--- a/loopbloom/core/models.py
+++ b/loopbloom/core/models.py
@@ -39,6 +39,9 @@ class MicroGoal(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     # History of successes/failures for this micro-habit.
     checkins: list[Checkin] = Field(default_factory=list)
+    # Optional progression overrides for this specific micro-habit.
+    advancement_window: int | None = None
+    advancement_threshold: float | None = None
 
     @field_validator("name")
     def _strip(cls, v: str) -> str:  # noqa: D401

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -32,10 +32,16 @@ def should_advance(
 ) -> bool:
     """Return True if micro-habit qualifies for advancement.
 
-    If ``window`` or ``threshold`` are omitted, values are read from
-    ``loopbloom.core.config`` (keys ``advance.window`` and
+    If ``window`` or ``threshold`` are omitted, values are looked up on the
+    ``micro`` object first (``advancement_window`` and
+    ``advancement_threshold``).  When those aren't defined, global defaults from
+    :mod:`loopbloom.core.config` are used (keys ``advance.window`` and
     ``advance.threshold``).
     """
+    if window is None:
+        window = micro.advancement_window
+    if threshold is None:
+        threshold = micro.advancement_threshold
     if window is None or threshold is None:
         # Pull defaults from the user's config so behaviour can be tuned
         # without modifying library code.

--- a/tests/unit/test_progression.py
+++ b/tests/unit/test_progression.py
@@ -37,3 +37,21 @@ def test_should_advance_respects_config(monkeypatch) -> None:
         lambda: {"advance": {"threshold": 0.5, "window": 2}},
     )
     assert should_advance(mg)
+
+
+def test_microgoal_custom_criteria(monkeypatch) -> None:
+    """Per-micro-goal settings override global config."""
+    mg = MicroGoal(
+        name="Custom",
+        advancement_window=3,
+        advancement_threshold=0.6,
+    )
+    for i in range(3):
+        day = TODAY - timedelta(days=i)
+        mg.checkins.append(Checkin(date=day, success=i != 1))
+    # Global config would fail this streak, but custom criteria should pass.
+    monkeypatch.setattr(
+        "loopbloom.core.config.load",
+        lambda: {"advance": {"threshold": 0.99, "window": 14}},
+    )
+    assert should_advance(mg)


### PR DESCRIPTION
## Summary
- extend `MicroGoal` model with `advancement_window` and `advancement_threshold`
- use micro-goal overrides in `should_advance`
- test per-micro-goal progression logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646dfb4a708322bc430fc74c8b2b30