### PR TITLE
Add line chart report mode

### DIFF
--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from calendar import Calendar, month_name
-from datetime import date
+from datetime import date, timedelta
 from typing import Iterable, Iterator, List
 
 import click
@@ -23,7 +23,7 @@ console = Console()
 )
 @click.option(
     "--mode",
-    type=click.Choice(["calendar", "success"], case_sensitive=False),
+    type=click.Choice(["calendar", "success", "line"], case_sensitive=False),
     default="calendar",
     help="Report type to display.",
 )
@@ -32,6 +32,8 @@ def report(mode: str, goals: List[GoalArea]) -> None:
     """Display advanced reports based on ``mode``."""
     if mode == "success":
         _success_bars(goals)
+    elif mode == "line":
+        _line_chart(goals)
     else:
         _calendar_heatmap(goals)
 
@@ -65,10 +67,7 @@ def _calendar_heatmap(goals: List[GoalArea]) -> None:
                 stats[ci.date.day] = (succ, tot)
 
     weeks = cal.monthdayscalendar(today.year, today.month)
-    title = (
-        "LoopBloom Check-in Heatmap – "
-        f"{month_name[today.month]} {today.year}"
-    )
+    title = "LoopBloom Check-in Heatmap – " f"{month_name[today.month]} {today.year}"
     console.print(f"[bold]{title}[/bold]")
     for week in weeks:
         line = ""
@@ -108,3 +107,34 @@ def _success_bars(goals: List[GoalArea]) -> None:
             ratio = "–"
         table.add_row(g.name, ratio)
     console.print(table)
+
+
+def _line_chart(goals: List[GoalArea]) -> None:
+    """Show a line chart of daily success rates over the last 30 days."""
+    import plotext as plt
+
+    today = date.today()
+    start = today - timedelta(days=29)
+
+    rates: list[float] = []
+    for i in range(30):
+        day = start + timedelta(days=i)
+        successes = 0
+        total = 0
+        for m in _gather_all_micro(goals):
+            for ci in m.checkins:
+                if ci.date == day:
+                    total += 1
+                    if ci.success:
+                        successes += 1
+        rate = (successes / total) * 100 if total else 0
+        rates.append(rate)
+
+    x = list(range(30))
+    plt.clear_data()
+    plt.clear_figure()
+    plt.plot(x, rates)
+    plt.title("Success Rate (Last 30 Days)")
+    plt.ylim(0, 100)
+    plt.yticks([0, 25, 50, 75, 100])
+    plt.show()

--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -67,7 +67,10 @@ def _calendar_heatmap(goals: List[GoalArea]) -> None:
                 stats[ci.date.day] = (succ, tot)
 
     weeks = cal.monthdayscalendar(today.year, today.month)
-    title = "LoopBloom Check-in Heatmap – " f"{month_name[today.month]} {today.year}"
+    title = (
+        "LoopBloom Check-in Heatmap – "
+        f"{month_name[today.month]} {today.year}"
+    )
     console.print(f"[bold]{title}[/bold]")
     for week in weeks:
         line = ""

--- a/poetry.lock
+++ b/poetry.lock
@@ -458,6 +458,23 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-
 type = ["mypy (>=1.14.1)"]
 
 [[package]]
+name = "plotext"
+version = "5.3.2"
+description = "plotext plots directly on terminal"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "plotext-5.3.2-py3-none-any.whl", hash = "sha256:394362349c1ddbf319548cfac17ca65e6d5dfc03200c40dfdc0503b3e95a2283"},
+    {file = "plotext-5.3.2.tar.gz", hash = "sha256:52d1e932e67c177bf357a3f0fe6ce14d1a96f7f7d5679d7b455b929df517068e"},
+]
+
+[package.extras]
+completion = ["shtab"]
+image = ["pillow (>=8.4)"]
+video = ["ffpyplayer (>=4.3.5)", "opencv-python (>=4.5.5)", "pafy (>=0.5.5)", "pillow (>=8.4)", "youtube-dl (==2020.12.2)"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -995,4 +1012,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d58a221a90e1708408517b49fe7e144fa850ae9258e43c21a7e054320e62c521"
+content-hash = "e75219a36d2831574a6b48e690ea98e6d43b05f9d90feb16b0c799d6d3e407ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ tomli-w = "*"
 plyer = "^2.1.0"
 sqlalchemy = "^2.0.41"
 aiosqlite = "^0.21.0"
+plotext = "5.3.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/tests/integration/test_report_cmd.py
+++ b/tests/integration/test_report_cmd.py
@@ -18,3 +18,5 @@ def test_report_command_outputs(tmp_path) -> None:  # noqa: D103
     assert "Health" in res.output
     res2 = runner.invoke(cli, ["report", "--mode", "calendar"], env=env)
     assert "Heatmap" in res2.output
+    res3 = runner.invoke(cli, ["report", "--mode", "line"], env=env)
+    assert "Success Rate" in res3.output

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -2,18 +2,19 @@
 
 from datetime import date
 
-from loopbloom.cli.report import _calendar_heatmap, _success_bars
+from loopbloom.cli.report import _calendar_heatmap, _line_chart, _success_bars
 from loopbloom.core.models import Checkin, GoalArea, MicroGoal
 
 
 def test_report_helpers(capsys) -> None:  # noqa: D103
     goal = GoalArea(name="G", micro_goals=[MicroGoal(name="M")])
-    goal.micro_goals[0].checkins.append(
-        Checkin(date=date.today(), success=True)
-    )
+    goal.micro_goals[0].checkins.append(Checkin(date=date.today(), success=True))
     _calendar_heatmap([goal])
     out = capsys.readouterr().out
     assert "LoopBloom Check-in Heatmap" in out
     _success_bars([goal])
     out2 = capsys.readouterr().out
     assert "Success Rates per Goal" in out2
+    _line_chart([goal])
+    out3 = capsys.readouterr().out
+    assert "Success Rate" in out3

--- a/tests/unit/test_report_cli.py
+++ b/tests/unit/test_report_cli.py
@@ -2,13 +2,19 @@
 
 from datetime import date
 
-from loopbloom.cli.report import _calendar_heatmap, _line_chart, _success_bars
+from loopbloom.cli.report import (
+    _calendar_heatmap,
+    _line_chart,
+    _success_bars,
+)
 from loopbloom.core.models import Checkin, GoalArea, MicroGoal
 
 
 def test_report_helpers(capsys) -> None:  # noqa: D103
     goal = GoalArea(name="G", micro_goals=[MicroGoal(name="M")])
-    goal.micro_goals[0].checkins.append(Checkin(date=date.today(), success=True))
+    goal.micro_goals[0].checkins.append(
+        Checkin(date=date.today(), success=True)
+    )
     _calendar_heatmap([goal])
     out = capsys.readouterr().out
     assert "LoopBloom Check-in Heatmap" in out


### PR DESCRIPTION
## Summary
- extend the report command with a `line` mode
- render a 30‑day success rate line chart using `plotext`
- add `plotext` as a project dependency
- test the new line chart helper and CLI option

## Testing
- `pre-commit run --files loopbloom/cli/report.py tests/unit/test_report_cli.py tests/integration/test_report_cmd.py pyproject.toml poetry.lock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864737b92ec83228814044f95c01079