### PR TITLE
Add backup command

### DIFF
--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 import click
 from click import Command
 
+from loopbloom.cli.backup import backup  # NEW
 from loopbloom.cli.checkin import checkin
 from loopbloom.cli.config import config  # NEW
 from loopbloom.cli.cope import cope  # NEW
@@ -46,18 +47,12 @@ def cli(ctx: click.Context) -> None:
     if storage_type == "sqlite":
         # Environment variable overrides config which overrides the default.
         path = (
-            os.getenv("LOOPBLOOM_SQLITE_PATH")
-            or cfg_path
-            or str(SQLITE_DEFAULT_PATH)
+            os.getenv("LOOPBLOOM_SQLITE_PATH") or cfg_path or str(SQLITE_DEFAULT_PATH)
         )
         store = SQLiteStore(path)
     else:
         # ``LOOPBLOOM_DATA_PATH`` or config ``data_path`` may override.
-        path = (
-            os.getenv("LOOPBLOOM_DATA_PATH")
-            or cfg_path
-            or str(JSON_DEFAULT_PATH)
-        )
+        path = os.getenv("LOOPBLOOM_DATA_PATH") or cfg_path or str(JSON_DEFAULT_PATH)
         store = JSONStore(path)
 
     # Expose the store instance to subcommands via Click's context object.
@@ -74,6 +69,7 @@ cli.add_command(report)
 cli.add_command(cope)
 cli.add_command(config)
 cli.add_command(export)
+cli.add_command(backup)
 cli.add_command(tree)
 cli.add_command(micro)
 

--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -46,13 +46,13 @@ def cli(ctx: click.Context) -> None:
     store: Storage
     if storage_type == "sqlite":
         # Environment variable overrides config which overrides the default.
-        path = (
-            os.getenv("LOOPBLOOM_SQLITE_PATH") or cfg_path or str(SQLITE_DEFAULT_PATH)
-        )
+        sqlite_env = os.getenv("LOOPBLOOM_SQLITE_PATH")
+        path = sqlite_env or cfg_path or str(SQLITE_DEFAULT_PATH)
         store = SQLiteStore(path)
     else:
         # ``LOOPBLOOM_DATA_PATH`` or config ``data_path`` may override.
-        path = os.getenv("LOOPBLOOM_DATA_PATH") or cfg_path or str(JSON_DEFAULT_PATH)
+        data_env = os.getenv("LOOPBLOOM_DATA_PATH")
+        path = data_env or cfg_path or str(JSON_DEFAULT_PATH)
         store = JSONStore(path)
 
     # Expose the store instance to subcommands via Click's context object.

--- a/loopbloom/cli/backup.py
+++ b/loopbloom/cli/backup.py
@@ -29,11 +29,11 @@ def backup() -> None:
     cfg_path = str(config.get("data_path") or "")
 
     if storage == "sqlite":
-        path = (
-            os.getenv("LOOPBLOOM_SQLITE_PATH") or cfg_path or str(SQLITE_DEFAULT_PATH)
-        )
+        sqlite_env = os.getenv("LOOPBLOOM_SQLITE_PATH")
+        path = sqlite_env or cfg_path or str(SQLITE_DEFAULT_PATH)
     else:
-        path = os.getenv("LOOPBLOOM_DATA_PATH") or cfg_path or str(JSON_DEFAULT_PATH)
+        data_env = os.getenv("LOOPBLOOM_DATA_PATH")
+        path = data_env or cfg_path or str(JSON_DEFAULT_PATH)
 
     src = Path(path)
     if not src.exists():

--- a/loopbloom/cli/backup.py
+++ b/loopbloom/cli/backup.py
@@ -1,0 +1,46 @@
+"""Backup current data file to ``APP_DIR/backups``."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+from loopbloom.core import config as cfg
+from loopbloom.storage.json_store import DEFAULT_PATH as JSON_DEFAULT_PATH
+from loopbloom.storage.sqlite_store import DEFAULT_PATH as SQLITE_DEFAULT_PATH
+
+
+def _backup_dir() -> Path:
+    """Return ``APP_DIR/backups`` ensuring it exists."""
+    path = cfg.APP_DIR / "backups"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@click.command(name="backup", help="Copy data file to backups directory.")
+def backup() -> None:
+    """Copy the active data file into :data:`BACKUP_DIR`."""
+    config = cfg.load()
+    storage = config.get("storage", "json")
+    cfg_path = str(config.get("data_path") or "")
+
+    if storage == "sqlite":
+        path = (
+            os.getenv("LOOPBLOOM_SQLITE_PATH") or cfg_path or str(SQLITE_DEFAULT_PATH)
+        )
+    else:
+        path = os.getenv("LOOPBLOOM_DATA_PATH") or cfg_path or str(JSON_DEFAULT_PATH)
+
+    src = Path(path)
+    if not src.exists():
+        click.echo(f"[red]Data file not found: {src}")
+        return
+
+    timestamp = datetime.now().isoformat(timespec="seconds").replace(":", "-")
+    dest = _backup_dir() / f"{src.stem}-backup-{timestamp}{src.suffix}"
+    shutil.copy2(src, dest)
+    click.echo(f"[green]Backup saved → {dest}")

--- a/tests/integration/test_backup_cmd.py
+++ b/tests/integration/test_backup_cmd.py
@@ -1,0 +1,31 @@
+"""Integration test for the ``backup`` command."""
+
+import importlib
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def test_backup_creates_file(tmp_path, monkeypatch):
+    """Running ``backup`` copies the active data file."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    data_file = tmp_path / "data.json"
+    monkeypatch.setenv("LOOPBLOOM_DATA_PATH", str(data_file))
+    monkeypatch.delenv("LOOPBLOOM_SQLITE_PATH", raising=False)
+
+    import loopbloom.core.config as cfg_mod
+
+    importlib.reload(cfg_mod)
+    import loopbloom.__main__ as main
+
+    importlib.reload(main)
+
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    runner.invoke(main.cli, ["goal", "add", "Keep"], env=env)
+    res = runner.invoke(main.cli, ["backup"], env=env)
+    assert res.exit_code == 0
+    backup_dir = Path(tmp_path) / "loopbloom" / "backups"
+    files = list(backup_dir.iterdir())
+    assert files and "backup" in files[0].name


### PR DESCRIPTION
## Summary
- implement new `backup` command
- register it in the CLI
- add coverage for the backup workflow

## Testing
- `pre-commit run --files loopbloom/cli/backup.py loopbloom/__main__.py tests/integration/test_backup_cmd.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686479281968832293a72cd32948cd4b