### PR TITLE
Enhance export command help

### DIFF
--- a/loopbloom/cli/export.py
+++ b/loopbloom/cli/export.py
@@ -10,11 +10,25 @@ from loopbloom.storage.base import Storage
 
 
 @click.command(name="export", help="Export data to CSV or JSON.")
-@click.option("--fmt", type=click.Choice(["csv", "json"]), required=True)
-@click.option("--out", "out_path", type=click.Path(), required=True)
+@click.option(
+    "--fmt",
+    type=click.Choice(["csv", "json"]),
+    required=True,
+    help="Output format (csv or json).",
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(),
+    required=True,
+    help="File to write exported data to.",
+)
 @click.pass_obj
 def export(store: Storage, fmt: str, out_path: str) -> None:
-    """Write all goal history to OUT_PATH in format FMT."""
+    """Write all goal history to OUT_PATH in format FMT.
+
+    Usage: ``loopbloom export --fmt csv --out progress.csv``
+    """
     # Load all goals from the configured storage backend.
     goals = store.load()
 


### PR DESCRIPTION
## Summary
- document output format on `--fmt`
- describe exported file path on `--out`
- expand export command docstring with a usage example

## Testing
- `pip install .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686479312a308322b1beaacdb363eddb