### PR TITLE
Add integration test for new goal creation

### DIFF
--- a/tests/integration/test_goal_add_new_goal.py
+++ b/tests/integration/test_goal_add_new_goal.py
@@ -1,0 +1,20 @@
+import os
+from click.testing import CliRunner
+
+
+def test_add_new_goal(tmp_path) -> None:
+    """Add goal then verify it shows up in goal list."""
+    runner = CliRunner()
+    data_file = tmp_path / "data.json"
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
+    from loopbloom import __main__ as main
+    cli = main.cli
+
+    res = runner.invoke(cli, ["goal", "add", "New Goal"], env=env)
+    assert res.exit_code == 0
+    assert "Added goal:" in res.output
+
+    res = runner.invoke(cli, ["goal", "list"], env=env)
+    assert "New Goal" in res.output


### PR DESCRIPTION
## Summary
- ensure we can add a goal via CLI and list it

## Testing
- `pytest -q tests/integration/test_goal_add_new_goal.py::test_add_new_goal`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648c035e388322a333201fe5f76034