### PR TITLE
Add integration test for listing multiple goals

### DIFF
--- a/tests/integration/test_goal_add_new_goal.py
+++ b/tests/integration/test_goal_add_new_goal.py
@@ -1,4 +1,7 @@
+"""Integration tests covering goal creation and listing."""
+
 import os
+
 from click.testing import CliRunner
 
 
@@ -10,6 +13,7 @@ def test_add_new_goal(tmp_path) -> None:
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     res = runner.invoke(cli, ["goal", "add", "New Goal"], env=env)
@@ -18,3 +22,23 @@ def test_add_new_goal(tmp_path) -> None:
 
     res = runner.invoke(cli, ["goal", "list"], env=env)
     assert "New Goal" in res.output
+
+
+def test_goal_list_multiple_goals(tmp_path) -> None:
+    """View all goals after adding several."""
+    runner = CliRunner()
+    data_file = tmp_path / "data.json"
+    env = {"LOOPBLOOM_DATA_PATH": str(data_file)}
+
+    os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
+    from loopbloom import __main__ as main
+
+    cli = main.cli
+
+    for name in ["Goal A", "Goal B", "Goal C"]:
+        res = runner.invoke(cli, ["goal", "add", name], env=env)
+        assert res.exit_code == 0
+
+    res = runner.invoke(cli, ["goal", "list"], env=env)
+    for name in ["Goal A", "Goal B", "Goal C"]:
+        assert name in res.output


### PR DESCRIPTION
## Summary
- verify that listing multiple goals shows them all in the output

## Testing
- `pre-commit run --files tests/integration/test_goal_add_new_goal.py`
- `pytest -q tests/integration/test_goal_add_new_goal.py`


------
https://chatgpt.com/codex/tasks/task_e_68648d71ac788322bad950b9f3739f08