### PR TITLE
Add integration test for successful check-in

### DIFF
--- a/tests/integration/test_checkin_success.py
+++ b/tests/integration/test_checkin_success.py
@@ -25,7 +25,8 @@ def test_successful_checkin(tmp_path) -> None:
     res = runner.invoke(cli, ["checkin", "Goal Name", "--success"], env=env)
 
     assert res.exit_code == 0
-    assert any(k in res.output for k in ("\u2713", "Great", "Amazing", "Awesome"))
+    expected_phrases = ("\u2713", "Great", "Amazing", "Awesome")
+    assert any(k in res.output for k in expected_phrases)
 
     data = json.loads((tmp_path / "data.json").read_text())
     assert data[0]["micro_goals"][0]["checkins"][0]["success"] is True

--- a/tests/integration/test_checkin_success.py
+++ b/tests/integration/test_checkin_success.py
@@ -1,0 +1,31 @@
+"""Integration test for successful check-in flow."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from loopbloom.__main__ import cli
+
+
+def test_successful_checkin(tmp_path) -> None:
+    """Add a goal and micro-habit then log a successful check-in."""
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    # Setup goal and micro-habit
+    runner.invoke(cli, ["goal", "add", "Goal Name"], env=env)
+    runner.invoke(
+        cli,
+        ["micro", "add", "Tiny Habit", "--goal", "Goal Name"],
+        env=env,
+    )
+
+    res = runner.invoke(cli, ["checkin", "Goal Name", "--success"], env=env)
+
+    assert res.exit_code == 0
+    assert any(k in res.output for k in ("\u2713", "Great", "Amazing", "Awesome"))
+
+    data = json.loads((tmp_path / "data.json").read_text())
+    assert data[0]["micro_goals"][0]["checkins"][0]["success"] is True


### PR DESCRIPTION
## Summary
- add a new integration test verifying successful check-ins report positive feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649912059483228df828ff323a4090