### PR TITLE
Fix version mismatch in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,9 @@
-
-[project]
-name = "loopbloom-cli"
-version = "0.0.1"
-description = "ADHD Habit Stacking Tool"
-readme = "README.md"
-authors = [{name = "Your Name", email = "you@example.com"}]
-requires-python = ">=3.8"
-
-
 [tool.poetry]
 name = "loopbloom-cli"
-version = "0.0.0"
+version = "0.0.1"
 description = "Compassion-first micro-habit tracker for the terminal."
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
 packages = [{ include = "loopbloom" }]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary
- remove redundant `[project]` section
- set version in `[tool.poetry]` to `0.0.1`
- add author and readme info to `[tool.poetry]`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6864991cc2dc83229dcc007e73950932