### PR TITLE
Add failed check-in test and support flag

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -18,15 +18,22 @@ from loopbloom.core.talks import TalkPool
 
 @click.command(
     name="checkin",
-    help="Record today’s success or skip for a goal.",
+    help="Record today’s success, skip, or failure for a goal.",
 )
 @click.argument("goal_name", required=False)
 @click.option("--success/--skip", default=True, help="Mark success or skip.")
+@click.option(
+    "--fail",
+    is_flag=True,
+    default=False,
+    help="Alias for --skip to record a failed check-in.",
+)
 @click.option("--note", default="", help="Optional note.")
 @with_goals
 def checkin(
     goal_name: Optional[str],
     success: bool,
+    fail: bool,
     note: str,
     goals: List[GoalArea],
 ) -> None:
@@ -36,7 +43,10 @@ def checkin(
     goal to check in for.
     """
     # ``success`` determines which pep-talk pool we draw from. ``note`` is an
-    # optional free-form comment stored alongside the check-in.
+    # optional free-form comment stored alongside the check-in. ``fail`` is an
+    # alias for ``--skip`` and overrides ``success`` when provided.
+    if fail:
+        success = False
     # If the user did not specify which goal to log, prompt with a list.
     if goal_name is None:
         names = [g.name for g in goals]

--- a/tests/integration/test_checkin_fail.py
+++ b/tests/integration/test_checkin_fail.py
@@ -1,0 +1,32 @@
+"""Integration test for failed check-in flow."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from loopbloom.__main__ import cli
+
+
+def test_failed_checkin(tmp_path) -> None:
+    """Add a goal/micro-habit then log a failed check-in."""
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    # Setup goal and micro-habit
+    runner.invoke(cli, ["goal", "add", "Goal Name"], env=env)
+    runner.invoke(
+        cli,
+        ["micro", "add", "Tiny Habit", "--goal", "Goal Name"],
+        env=env,
+    )
+
+    res = runner.invoke(cli, ["checkin", "Goal Name", "--fail"], env=env)
+
+    assert res.exit_code == 0
+    expected_phrases = ("Skipped", "data, not drama", "No worries")
+    assert any(k in res.output for k in expected_phrases)
+
+    data = json.loads((tmp_path / "data.json").read_text())
+    assert data[0]["micro_goals"][0]["checkins"][0]["success"] is False


### PR DESCRIPTION
## Summary
- allow `loopbloom checkin` to accept a `--fail` flag
- test failed check-in flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649e070f488322a2998c074af9258d