### PR TITLE
Add goal-specific progress summary test

### DIFF
--- a/tests/integration/test_checkin_and_summary.py
+++ b/tests/integration/test_checkin_and_summary.py
@@ -47,7 +47,11 @@ def test_goal_specific_progress(tmp_path) -> None:
 
     # Create goal and micro-habit
     runner.invoke(cli, ["goal", "add", "Focus"], env=env)
-    runner.invoke(cli, ["micro", "add", "Meditate", "--goal", "Focus"], env=env)
+    runner.invoke(
+        cli,
+        ["micro", "add", "Meditate", "--goal", "Focus"],
+        env=env,
+    )
 
     # Log multiple check-ins
     for _ in range(3):

--- a/tests/integration/test_checkin_and_summary.py
+++ b/tests/integration/test_checkin_and_summary.py
@@ -38,3 +38,21 @@ def test_checkin_generates_peptalk_and_summary(tmp_path) -> None:
     # Summary per-goal
     res = runner.invoke(cli, ["summary", "--goal", "Exercise"], env=env)
     assert "Exercise" in res.output and "Walk 5 min" in res.output
+
+
+def test_goal_specific_progress(tmp_path) -> None:
+    """Detailed success stats show for a single goal."""
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    # Create goal and micro-habit
+    runner.invoke(cli, ["goal", "add", "Focus"], env=env)
+    runner.invoke(cli, ["micro", "add", "Meditate", "--goal", "Focus"], env=env)
+
+    # Log multiple check-ins
+    for _ in range(3):
+        runner.invoke(cli, ["checkin", "Focus", "--success"], env=env)
+
+    res = runner.invoke(cli, ["summary", "--goal", "Focus"], env=env)
+    assert "Focus" in res.output and "Meditate" in res.output
+    assert "Success rate last" in res.output


### PR DESCRIPTION
## Summary
- test success rate detail view for one goal

## Testing
- `pytest -q`
- `pytest tests/integration/test_checkin_and_summary.py::test_goal_specific_progress -q`


------
https://chatgpt.com/codex/tasks/task_e_6864a388dd248322a4a00dbbe816441b