### PR TITLE
Add journal CLI command

### DIFF
--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -20,6 +20,7 @@ from loopbloom.cli.micro import micro
 from loopbloom.cli.report import report
 from loopbloom.cli.summary import summary
 from loopbloom.cli.tree import tree
+from loopbloom.cli.journal import journal
 from loopbloom.core import config as cfg
 from loopbloom.storage.base import Storage
 from loopbloom.storage.json_store import (
@@ -77,6 +78,7 @@ cli.add_command(export)
 cli.add_command(backup)
 cli.add_command(tree)
 cli.add_command(micro)
+cli.add_command(journal)
 
 if __name__ == "__main__":
     cli()

--- a/loopbloom/cli/journal.py
+++ b/loopbloom/cli/journal.py
@@ -1,0 +1,16 @@
+"""Add free-form journal entries."""
+
+from __future__ import annotations
+
+import click
+
+from loopbloom.core import journal as jr
+
+
+@click.command(name="journal", help="Record a journal entry.")
+@click.argument("text")
+@click.option("--goal", "goal_name", default=None, help="Tag entry with a goal.")
+def journal(text: str, goal_name: str | None) -> None:
+    """Save ``text`` as a journal entry optionally linked to ``goal_name``."""
+    jr.add_entry(text, goal_name)
+    click.echo("[green]Entry saved.")

--- a/loopbloom/cli/journal.py
+++ b/loopbloom/cli/journal.py
@@ -9,7 +9,12 @@ from loopbloom.core import journal as jr
 
 @click.command(name="journal", help="Record a journal entry.")
 @click.argument("text")
-@click.option("--goal", "goal_name", default=None, help="Tag entry with a goal.")
+@click.option(
+    "--goal",
+    "goal_name",
+    default=None,
+    help="Tag entry with a goal.",
+)
 def journal(text: str, goal_name: str | None) -> None:
     """Save ``text`` as a journal entry optionally linked to ``goal_name``."""
     jr.add_entry(text, goal_name)

--- a/loopbloom/core/journal.py
+++ b/loopbloom/core/journal.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
-from pathlib import Path
 from typing import List
 
 from pydantic import BaseModel, Field

--- a/loopbloom/core/journal.py
+++ b/loopbloom/core/journal.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import List
+
+from pydantic import BaseModel, Field
+from pydantic.json import pydantic_encoder
+
+from loopbloom.core.config import APP_DIR
+
+JOURNAL_PATH = APP_DIR / "journal.json"
+JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+class JournalEntry(BaseModel):
+    """Simple journal entry with optional goal tag."""
+
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    text: str
+    goal: str | None = None
+
+
+def load_entries() -> List[JournalEntry]:
+    """Return all stored journal entries."""
+    if not JOURNAL_PATH.exists():
+        return []
+    with JOURNAL_PATH.open("r", encoding="utf-8") as fp:
+        raw = json.load(fp)
+    return [JournalEntry.model_validate(obj) for obj in raw]
+
+
+def add_entry(text: str, goal: str | None = None) -> None:
+    """Append a new journal entry to the file."""
+    entries = load_entries()
+    entries.append(JournalEntry(text=text.strip(), goal=goal))
+    with JOURNAL_PATH.open("w", encoding="utf-8") as fp:
+        json.dump(entries, fp, default=pydantic_encoder, indent=2)

--- a/tests/unit/test_journal_cli.py
+++ b/tests/unit/test_journal_cli.py
@@ -21,7 +21,11 @@ def _reload_cli(tmp_path: Path, monkeypatch) -> any:
 def test_journal_creates_entry(tmp_path: Path, monkeypatch) -> None:
     cli = _reload_cli(tmp_path, monkeypatch)
     runner = CliRunner()
-    res = runner.invoke(cli, ["journal", "test entry", "--goal", "Sleep"], env={})
+    res = runner.invoke(
+        cli,
+        ["journal", "test entry", "--goal", "Sleep"],
+        env={},
+    )
     assert "Entry saved" in res.output
     journal_file = Path(tmp_path) / "loopbloom" / "journal.json"
     data = json.loads(journal_file.read_text())

--- a/tests/unit/test_journal_cli.py
+++ b/tests/unit/test_journal_cli.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def _reload_cli(tmp_path: Path, monkeypatch) -> any:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    import loopbloom.core.config as cfg_mod
+    import loopbloom.core.journal as journal_mod
+    import loopbloom.__main__ as main
+    importlib.reload(cfg_mod)
+    importlib.reload(journal_mod)
+    importlib.reload(main)
+    return main.cli
+
+
+def test_journal_creates_entry(tmp_path: Path, monkeypatch) -> None:
+    cli = _reload_cli(tmp_path, monkeypatch)
+    runner = CliRunner()
+    res = runner.invoke(cli, ["journal", "test entry", "--goal", "Sleep"], env={})
+    assert "Entry saved" in res.output
+    journal_file = Path(tmp_path) / "loopbloom" / "journal.json"
+    data = json.loads(journal_file.read_text())
+    assert data[0]["text"] == "test entry"
+    assert data[0]["goal"] == "Sleep"


### PR DESCRIPTION
## Summary
- implement a new journal command for free-form entries
- persist journal entries in journal.json
- hook journal command into CLI
- cover functionality with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a538b85083229024ae07eefdc8be