### PR TITLE
Add coping plan run test

### DIFF
--- a/tests/integration/test_coping_plan_run.py
+++ b/tests/integration/test_coping_plan_run.py
@@ -1,0 +1,23 @@
+from click.testing import CliRunner
+from loopbloom.__main__ import cli
+
+
+def test_running_coping_plan(tmp_path) -> None:
+    """Test Case 4.2: Running a Coping Plan."""
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    # Provide answers for the two prompts in the built-in plan.
+    user_input = "\n".join(["inbox backlog", "sort emails"]) + "\n"
+    result = runner.invoke(
+        cli,
+        ["cope", "run", "overwhelmed"],
+        env=env,
+        input=user_input,
+    )
+
+    assert result.exit_code == 0
+    assert "Feeling Overwhelmed" in result.output
+    assert "Identify the biggest stressor" in result.output
+    assert "Pick one micro-action" in result.output
+    assert "Great job" in result.output


### PR DESCRIPTION
## Summary
- add integration test for coping plan execution prompts

## Testing
- `flake8`
- `mypy loopbloom`
- `pytest --cov=loopbloom --cov-fail-under=80 -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a8226a288322a9958e7a6c22c0f7