### PR TITLE
Implement review command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ GOALS & MICRO-HABITS
 CHECK-INS & FEEDBACK
   loopbloom checkin   [--goal <name>] [--status done|skip] [--note ..]
   loopbloom summary   [--goal <name>]   # streak banner, next steps
+  loopbloom review    [--period day|week]   # reflect on progress
 
 COPING & SUPPORT
   loopbloom cope list           # view plan names

--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -21,6 +21,7 @@ from loopbloom.cli.report import report
 from loopbloom.cli.summary import summary
 from loopbloom.cli.tree import tree
 from loopbloom.cli.journal import journal
+from loopbloom.cli.review import review
 from loopbloom.core import config as cfg
 from loopbloom.storage.base import Storage
 from loopbloom.storage.json_store import (
@@ -79,6 +80,7 @@ cli.add_command(backup)
 cli.add_command(tree)
 cli.add_command(micro)
 cli.add_command(journal)
+cli.add_command(review)
 
 if __name__ == "__main__":
     cli()

--- a/loopbloom/cli/review.py
+++ b/loopbloom/cli/review.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import click
+
+from loopbloom.core import review as rv
+
+
+@click.command(name="review", help="Reflect on your progress.")
+@click.option(
+    "--period",
+    default="day",
+    help="Time period for the review (e.g., day or week).",
+)
+def review(period: str) -> None:
+    """Interactive prompt that saves a review entry."""
+    answer = click.prompt("What went well?")
+    rv.add_entry(period=period, went_well=answer)
+    click.echo("[green]Review saved.")

--- a/loopbloom/core/review.py
+++ b/loopbloom/core/review.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from typing import List
+
+from pydantic import BaseModel, Field
+from pydantic.json import pydantic_encoder
+
+from loopbloom.core.config import APP_DIR
+
+REVIEW_PATH = APP_DIR / "reviews.json"
+REVIEW_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+class ReviewEntry(BaseModel):
+    """Reflection entry for a given period."""
+
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    period: str
+    went_well: str
+
+
+def load_entries() -> List[ReviewEntry]:
+    """Return saved review entries."""
+    if not REVIEW_PATH.exists():
+        return []
+    with REVIEW_PATH.open("r", encoding="utf-8") as fp:
+        raw = json.load(fp)
+    return [ReviewEntry.model_validate(obj) for obj in raw]
+
+
+def add_entry(period: str, went_well: str) -> None:
+    """Persist a new review entry."""
+    entries = load_entries()
+    entries.append(ReviewEntry(period=period, went_well=went_well.strip()))
+    with REVIEW_PATH.open("w", encoding="utf-8") as fp:
+        json.dump(entries, fp, default=pydantic_encoder, indent=2)

--- a/tests/unit/test_review_cli.py
+++ b/tests/unit/test_review_cli.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def _reload_cli(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    import loopbloom.core.config as cfg_mod
+    import loopbloom.core.review as review_mod
+    import loopbloom.__main__ as main
+    importlib.reload(cfg_mod)
+    importlib.reload(review_mod)
+    importlib.reload(main)
+    return main.cli
+
+
+def test_review_creates_entry(tmp_path: Path, monkeypatch) -> None:
+    cli = _reload_cli(tmp_path, monkeypatch)
+    runner = CliRunner()
+    res = runner.invoke(
+        cli,
+        ["review", "--period", "week"],
+        input="Great progress\n",
+    )
+    assert "Review saved" in res.output
+    review_file = Path(tmp_path) / "loopbloom" / "reviews.json"
+    data = json.loads(review_file.read_text())
+    assert data[0]["period"] == "week"
+    assert data[0]["went_well"] == "Great progress"


### PR DESCRIPTION
## Summary
- add a `review` command for periodic reflection
- document the command in the README cheat sheet
- provide storage helpers for reviews
- wire the command into the CLI
- test that reviews are recorded

## Testing
- `poetry run ./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6864a7e0ed088322a407e0301324553b