### PR TITLE
Add logging utilities and integrate with CLI

### DIFF
--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -5,10 +5,13 @@ storage backend based on the user's configuration.
 """
 
 import os
+import logging
 from typing import TYPE_CHECKING, cast
 
 import click
 from click import Command
+
+from loopbloom.logging import setup_logging
 
 from loopbloom.cli.backup import backup  # NEW
 from loopbloom.cli.checkin import checkin
@@ -41,10 +44,13 @@ if TYPE_CHECKING:  # pragma: no cover - hints for mypy
 
 
 @click.group()
+@click.option("--verbose", is_flag=True, help="Enable debug logging.")
 @click.pass_context
-def cli(ctx: click.Context) -> None:
+def cli(ctx: click.Context, verbose: bool) -> None:
     """LoopBloom – tiny habits, big momentum."""
     # Load user configuration to determine which storage backend to use.
+    setup_logging(level=logging.DEBUG if verbose else logging.INFO)
+
     config = cfg.load()
     storage_type = config.get("storage", "json")
     cfg_path = str(config.get("data_path") or "")

--- a/loopbloom/cli/config.py
+++ b/loopbloom/cli/config.py
@@ -9,8 +9,11 @@ import json
 from typing import Any
 
 import click
+import logging
 
 from loopbloom.core import config as cfg
+
+logger = logging.getLogger(__name__)
 
 
 @click.group(name="config", help="View or change LoopBloom settings.")
@@ -26,6 +29,7 @@ def config() -> None:
 def _view() -> None:
     """Print the entire configuration as JSON."""
     # ``json.dumps`` makes the output easier to pipe into other tools.
+    logger.info("Viewing config")
     click.echo(json.dumps(cfg.load(), indent=2))
 
 
@@ -40,9 +44,11 @@ def _get(key: str) -> None:
     for part in key.split("."):
         val = val.get(part) if isinstance(val, dict) else None
     if val is None:
+        logger.error("Config key not found: %s", key)
         click.echo("[red]Key not found.")
         click.echo("Run 'loopbloom config view' to inspect available keys.")
     else:
+        logger.info("Config get %s -> %s", key, val)
         click.echo(val)
 
 
@@ -73,4 +79,5 @@ def _set(key: str, value: str) -> None:
     # Assign the converted value and persist.
     d[parts[-1]] = cast
     cfg.save(conf)
+    logger.info("Config set %s", key)
     click.echo("[green]Saved.")

--- a/loopbloom/cli/export.py
+++ b/loopbloom/cli/export.py
@@ -10,8 +10,11 @@ import json
 from typing import List
 
 import click
+import logging
 
 from loopbloom.storage.base import Storage
+
+logger = logging.getLogger(__name__)
 
 
 @click.command(name="export", help="Export data to CSV or JSON.")
@@ -35,11 +38,13 @@ def export(store: Storage, fmt: str, out_path: str) -> None:
     Usage: ``loopbloom export --fmt csv --out progress.csv``
     """
     # Load all goals from the configured storage backend.
+    logger.info("Exporting data to %s as %s", out_path, fmt)
     goals = store.load()
 
     if fmt == "json":
         with open(out_path, "w", encoding="utf-8") as fp:
             json.dump([g.model_dump(mode="json") for g in goals], fp, indent=2)
+        logger.info("JSON export complete")
         click.echo(f"[green]Exported JSON → {out_path}")
         return
 
@@ -73,4 +78,5 @@ def export(store: Storage, fmt: str, out_path: str) -> None:
     with open(out_path, "w", newline="", encoding="utf-8") as fp:
         writer = csv.writer(fp)
         writer.writerows(rows)
+    logger.info("CSV export complete")
     click.echo(f"[green]Exported CSV → {out_path}")

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -314,7 +314,10 @@ def goal_wizard(goals: List[GoalArea]) -> None:
     new_goal.phases.append(new_phase)
     goals.append(new_goal)
     logger.info(
-        "Created goal %s with phase %s and micro %s", goal_name, phase_name, micro_name
+        "Created goal %s with phase %s and micro %s",
+        goal_name,
+        phase_name,
+        micro_name,
     )
 
     msg = (

--- a/loopbloom/cli/journal.py
+++ b/loopbloom/cli/journal.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 )
 def journal(text: str, goal_name: str | None) -> None:
     """Save ``text`` as a journal entry optionally linked to ``goal_name``."""
-    logger.info("Adding journal entry%s", f" for {goal_name}" if goal_name else "")
+    logger.info(
+        "Adding journal entry%s",
+        f" for {goal_name}" if goal_name else "",
+    )
     jr.add_entry(text, goal_name)
     click.echo("[green]Entry saved.")

--- a/loopbloom/cli/journal.py
+++ b/loopbloom/cli/journal.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import click
+import logging
 
 from loopbloom.core import journal as jr
+
+logger = logging.getLogger(__name__)
 
 
 @click.command(name="journal", help="Record a journal entry.")
@@ -17,5 +20,6 @@ from loopbloom.core import journal as jr
 )
 def journal(text: str, goal_name: str | None) -> None:
     """Save ``text`` as a journal entry optionally linked to ``goal_name``."""
+    logger.info("Adding journal entry%s", f" for {goal_name}" if goal_name else "")
     jr.add_entry(text, goal_name)
     click.echo("[green]Entry saved.")

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -71,7 +71,11 @@ def micro_complete(
         # When a phase is provided we search within it.
         p = _find_phase(g, phase_name)
         if not p:
-            logger.error("Phase not found for micro complete: %s/%s", goal_name, phase_name)
+            logger.error(
+                "Phase not found for micro complete: %s/%s",
+                goal_name,
+                phase_name,
+            )
             click.echo(f"[red]Phase '{phase_name}' not found.")
             return
         target_list = p.micro_goals
@@ -127,7 +131,11 @@ def micro_cancel(
         # Search within the specified phase when provided.
         p = _find_phase(g, phase_name)
         if not p:
-            logger.error("Phase not found for micro cancel: %s/%s", goal_name, phase_name)
+            logger.error(
+                "Phase not found for micro cancel: %s/%s",
+                goal_name,
+                phase_name,
+            )
             click.echo(f"[red]Phase '{phase_name}' not found.")
             return
         target_list = p.micro_goals
@@ -255,7 +263,11 @@ def micro_rm(
         # Narrow search to a specific phase when supplied.
         p = _find_phase(g, phase_name)
         if not p:
-            logger.error("Phase not found for micro rm: %s/%s", goal_name, phase_name)
+            logger.error(
+                "Phase not found for micro rm: %s/%s",
+                goal_name,
+                phase_name,
+            )
             click.echo(f"[red]Phase '{phase_name}' not found.")
             return
         target_list = p.micro_goals

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -3,11 +3,14 @@
 from typing import List, Optional
 
 import click
+import logging
 
 from loopbloom.cli import with_goals
 from loopbloom.cli.interactive import choose_from
 from loopbloom.cli.utils import goal_not_found
 from loopbloom.core.models import GoalArea, MicroGoal, Phase, Status
+
+logger = logging.getLogger(__name__)
 
 
 def _find_goal(goals: List[GoalArea], name: str) -> Optional[GoalArea]:
@@ -59,6 +62,7 @@ def micro_complete(
     # Locate the parent goal first.
     g = _find_goal(goals, goal_name)
     if not g:
+        logger.error("Goal not found for micro complete: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])
         return
 
@@ -67,6 +71,7 @@ def micro_complete(
         # When a phase is provided we search within it.
         p = _find_phase(g, phase_name)
         if not p:
+            logger.error("Phase not found for micro complete: %s/%s", goal_name, phase_name)
             click.echo(f"[red]Phase '{phase_name}' not found.")
             return
         target_list = p.micro_goals
@@ -78,11 +83,13 @@ def micro_complete(
     mg = next((m for m in target_list if m.name.lower() == name.lower()), None)
     if not mg:
         loc = f"phase '{phase_name}'" if phase_name else f"goal '{goal_name}'"
+        logger.error("Micro-habit not found: %s in %s", name, loc)
         click.echo(f"[red]Micro-habit '{name}' not found in {loc}.")
         return
 
     # Persist the new lifecycle state.
     mg.status = Status.complete
+    logger.info("Marked micro-habit %s complete", name)
     click.echo(f"[green]Marked micro-habit '{name}' as complete.")
 
 
@@ -111,6 +118,7 @@ def micro_cancel(
     # Locate the goal that owns this micro-habit.
     g = _find_goal(goals, goal_name)
     if not g:
+        logger.error("Goal not found for micro cancel: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])
         return
 
@@ -119,6 +127,7 @@ def micro_cancel(
         # Search within the specified phase when provided.
         p = _find_phase(g, phase_name)
         if not p:
+            logger.error("Phase not found for micro cancel: %s/%s", goal_name, phase_name)
             click.echo(f"[red]Phase '{phase_name}' not found.")
             return
         target_list = p.micro_goals
@@ -129,11 +138,13 @@ def micro_cancel(
     mg = next((m for m in target_list if m.name.lower() == name.lower()), None)
     if not mg:
         loc = f"phase '{phase_name}'" if phase_name else f"goal '{goal_name}'"
+        logger.error("Micro-habit not found for cancel: %s in %s", name, loc)
         click.echo(f"[red]Micro-habit '{name}' not found in {loc}.")
         return
 
     # Mark the habit as cancelled without deleting history.
     mg.status = Status.cancelled
+    logger.info("Cancelled micro-habit %s", name)
     click.echo(f"[green]Cancelled micro-habit '{name}'.")
 
 
@@ -169,9 +180,11 @@ def micro_add(
     if goal_name is None:
         names = [g.name for g in goals]
         if not names:
+            logger.error("No goals available for micro add")
             click.echo("[red]No goals – use `loopbloom goal add`.")
             return
         click.echo("Select goal for new micro-habit:")
+        logger.info("Prompting for goal selection for micro add")
         goal_name = choose_from(names, "Enter number")
         if goal_name is None:
             return
@@ -179,12 +192,14 @@ def micro_add(
     # Ensure the referenced goal exists.
     g = _find_goal(goals, goal_name)
     if not g:
+        logger.error("Goal not found for micro add: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
         return  # pragma: no cover
 
     if phase_name is None:
         # Attach the new micro-habit directly to the goal.
         g.micro_goals.append(MicroGoal(name=name.strip()))
+        logger.info("Added micro-habit %s to goal %s", name, goal_name)
         click.echo(f"[green]Added micro-habit '{name}' to goal '{goal_name}'")
         return
 
@@ -194,11 +209,13 @@ def micro_add(
     if not p:
         p = Phase(name=phase_name.strip())
         g.phases.append(p)
+        logger.info("Created phase %s under %s", phase_name, goal_name)
         msg = f"[yellow]Created phase '{phase_name}' under goal '{goal_name}'."
         click.echo(msg)
     # Finally add the micro-habit under that phase.
     p.micro_goals.append(MicroGoal(name=name.strip()))
     msg = f"[green]Added micro-habit '{name}' to {goal_name}/{phase_name}"
+    logger.info("Added micro-habit %s to %s/%s", name, goal_name, phase_name)
     click.echo(msg)
 
 
@@ -229,6 +246,7 @@ def micro_rm(
     # Validate and locate the target goal.
     g = _find_goal(goals, goal_name)
     if not g:
+        logger.error("Goal not found for micro rm: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
         return  # pragma: no cover
 
@@ -237,6 +255,7 @@ def micro_rm(
         # Narrow search to a specific phase when supplied.
         p = _find_phase(g, phase_name)
         if not p:
+            logger.error("Phase not found for micro rm: %s/%s", goal_name, phase_name)
             click.echo(f"[red]Phase '{phase_name}' not found.")
             return
         target_list = p.micro_goals
@@ -247,6 +266,7 @@ def micro_rm(
     mg = next((m for m in target_list if m.name.lower() == name.lower()), None)
     if not mg:
         loc = f"phase '{phase_name}'" if phase_name else f"goal '{goal_name}'"
+        logger.error("Micro-habit not found for rm: %s in %s", name, loc)
         click.echo(f"[red]Micro-habit '{name}' not found in {loc}.")
         return
 
@@ -257,4 +277,5 @@ def micro_rm(
         return
 
     target_list.remove(mg)
+    logger.info("Deleted micro-habit %s", name)
     click.echo(f"[green]Deleted micro-habit:[/] {name}")

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -11,6 +11,7 @@ from datetime import date, timedelta
 from typing import List
 
 import click
+import logging
 from rich.console import Console, Group
 from rich.table import Table
 from rich.progress_bar import ProgressBar
@@ -22,6 +23,8 @@ from loopbloom.core.models import GoalArea
 from loopbloom.core.progression import should_advance
 
 console = Console()
+
+logger = logging.getLogger(__name__)
 
 WINDOW_DEFAULT = 14  # days
 
@@ -101,6 +104,7 @@ def _detail_view(goal_name: str, goals: List[GoalArea]) -> None:
     mg = g.get_active_micro_goal()
 
     if mg is None:
+        logger.info("No active micro-goal for %s", goal_name)
         click.echo("[yellow]No active micro-goal.")
         return
     successes = sum(ci.success for ci in mg.checkins[-window:])

--- a/loopbloom/cli/utils.py
+++ b/loopbloom/cli/utils.py
@@ -6,6 +6,7 @@ from difflib import get_close_matches
 from typing import Iterable
 
 import click
+import logging
 
 
 def suggest_name(name: str, options: Iterable[str]) -> str | None:
@@ -17,6 +18,8 @@ def suggest_name(name: str, options: Iterable[str]) -> str | None:
 
 def goal_not_found(name: str, goals: Iterable[str]) -> None:
     """Print helpful message when a goal is missing."""
+    logger = logging.getLogger(__name__)
+    logger.error("Goal not found: %s", name)
     click.echo(f"[red]Goal not found: \"{name}\".[/red]")
     # Suggest the closest existing goal to reduce user confusion.
     match = suggest_name(name, goals)

--- a/loopbloom/logging.py
+++ b/loopbloom/logging.py
@@ -1,0 +1,25 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from loopbloom.core.config import APP_DIR
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure root logger with a rotating file handler."""
+    log_dir = APP_DIR / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "loopbloom.log"
+
+    handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    # Avoid adding duplicate handlers if called multiple times
+    if not any(isinstance(h, RotatingFileHandler) and Path(h.baseFilename) == log_file for h in root_logger.handlers):
+        root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+

--- a/loopbloom/logging.py
+++ b/loopbloom/logging.py
@@ -19,7 +19,9 @@ def setup_logging(level: int = logging.INFO) -> None:
 
     root_logger = logging.getLogger()
     # Avoid adding duplicate handlers if called multiple times
-    if not any(isinstance(h, RotatingFileHandler) and Path(h.baseFilename) == log_file for h in root_logger.handlers):
+    if not any(
+        isinstance(h, RotatingFileHandler) and Path(h.baseFilename) == log_file
+        for h in root_logger.handlers
+    ):
         root_logger.addHandler(handler)
     root_logger.setLevel(level)
-


### PR DESCRIPTION
## Summary
- provide a `setup_logging` helper with rotating file handler
- initialise logging in `__main__` and add a global `--verbose` flag
- record load/save events in `JSONStore`
- log backup operations and CLI actions
- keep CLI output while logging important events

## Testing
- `flake8`
- `mypy --install-types --non-interactive loopbloom` *(fails: pydantic stubs missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864aaa8e1108322bc764297ffa98ee0