### PR TITLE
Refactor goal/phase lookups

### DIFF
--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -13,8 +13,6 @@ from loopbloom.core.models import GoalArea, MicroGoal, Phase
 logger = logging.getLogger(__name__)
 
 
-
-
 @click.group(name="goal", help="Manage goals, phases, and micro-habits.")
 def goal() -> None:
     """Goal-level commands."""

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -6,26 +6,13 @@ import click
 import logging
 
 from loopbloom.cli import with_goals
-from loopbloom.cli.utils import goal_not_found
+from loopbloom.cli.utils import goal_not_found, find_goal, find_phase
 from loopbloom.cli.interactive import choose_from
 from loopbloom.core.models import GoalArea, MicroGoal, Phase
 
 logger = logging.getLogger(__name__)
 
 
-def _find_goal(goals: List[GoalArea], name: str) -> Optional[GoalArea]:
-    """Return the goal matching ``name`` if present (case-insensitive)."""
-    # We keep goals in a list, so this helper does a simple linear search.
-    return next((g for g in goals if g.name.lower() == name.lower()), None)
-
-
-def _find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
-    """Return the phase within ``goal`` whose name matches ``name``."""
-    # Phases are looked up by name only since IDs are internal.
-    return next(
-        (p for p in goal.phases if p.name.lower() == name.lower()),
-        None,
-    )
 
 
 @click.group(name="goal", help="Manage goals, phases, and micro-habits.")
@@ -42,7 +29,7 @@ def goal() -> None:
 @with_goals
 def goal_add(name: str, notes: str, goals: List[GoalArea]) -> None:
     """Add a new goal area."""
-    if _find_goal(goals, name):
+    if find_goal(goals, name):
         logger.error("Goal already exists: %s", name)
         click.echo("[yellow]Goal already exists.")
         return
@@ -95,7 +82,7 @@ def goal_rm(
             return  # pragma: no cover
         name = selected
 
-    g = _find_goal(goals, name)
+    g = find_goal(goals, name)
     if not g:
         logger.error("Goal not found for deletion: %s", name)
         goal_not_found(name, [g.name for g in goals])
@@ -117,7 +104,7 @@ def goal_rm(
 @with_goals
 def goal_notes(name: str, text: Optional[str], goals: List[GoalArea]) -> None:
     """Display or update notes for ``name``."""
-    g = _find_goal(goals, name)
+    g = find_goal(goals, name)
     if not g:
         logger.error("Goal not found for notes: %s", name)
         goal_not_found(name, [x.name for x in goals])
@@ -172,12 +159,12 @@ def phase_add(
         if goal_name is None:
             return  # pragma: no cover
 
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
         return  # pragma: no cover
     # Avoid duplicates when the phase already exists.
-    if _find_phase(g, phase_name):
+    if find_phase(g, phase_name):
         logger.error("Phase already exists: %s/%s", goal_name, phase_name)
         click.echo("[yellow]Phase exists.")
         return
@@ -219,7 +206,7 @@ def phase_rm(
         if goal_name is None:
             return  # pragma: no cover
 
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         logger.error("Goal not found for phase removal: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
@@ -243,7 +230,7 @@ def phase_rm(
             return  # pragma: no cover
 
     # Locate the phase object for deletion.
-    p = _find_phase(g, phase_name)
+    p = find_phase(g, phase_name)
     if not p:
         logger.error("Phase not found: %s/%s", goal_name, phase_name)
         click.echo("[red]Phase not found.")  # pragma: no cover
@@ -271,12 +258,12 @@ def phase_notes(
     goals: List[GoalArea],
 ) -> None:
     """Display or update notes for a phase."""
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         logger.error("Goal not found for phase notes: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])
         return
-    p = _find_phase(g, phase_name)
+    p = find_phase(g, phase_name)
     if not p:
         logger.error("Phase not found for notes: %s/%s", goal_name, phase_name)
         click.echo("[red]Phase not found.")
@@ -301,7 +288,7 @@ def goal_wizard(goals: List[GoalArea]) -> None:
     logger.info("Starting goal wizard")
     click.echo("Let's set up your first goal!")
     goal_name = click.prompt("Goal name").strip()
-    if _find_goal(goals, goal_name):
+    if find_goal(goals, goal_name):
         logger.error("Goal already exists during wizard: %s", goal_name)
         click.echo("[red]Goal already exists.")
         return

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -13,8 +13,6 @@ from loopbloom.core.models import GoalArea, MicroGoal, Phase, Status
 logger = logging.getLogger(__name__)
 
 
-
-
 @click.group(name="micro", help="Micro-habit operations.")
 def micro() -> None:
     """Top-level micro-habit commands."""

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -7,26 +7,12 @@ import logging
 
 from loopbloom.cli import with_goals
 from loopbloom.cli.interactive import choose_from
-from loopbloom.cli.utils import goal_not_found
+from loopbloom.cli.utils import goal_not_found, find_goal, find_phase
 from loopbloom.core.models import GoalArea, MicroGoal, Phase, Status
 
 logger = logging.getLogger(__name__)
 
 
-def _find_goal(goals: List[GoalArea], name: str) -> Optional[GoalArea]:
-    """Return the goal with ``name`` if present (case-insensitive)."""
-    # ``GoalArea`` objects are stored in a simple list so we do a linear
-    # search. The number of goals is expected to be small.
-    return next((g for g in goals if g.name.lower() == name.lower()), None)
-
-
-def _find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
-    """Return phase from ``goal`` matching ``name`` if found."""
-    # Phases are also stored sequentially on the goal.
-    return next(
-        (p for p in goal.phases if p.name.lower() == name.lower()),
-        None,
-    )
 
 
 @click.group(name="micro", help="Micro-habit operations.")
@@ -60,7 +46,7 @@ def micro_complete(
 ) -> None:
     """Mark a micro-habit as complete."""
     # Locate the parent goal first.
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         logger.error("Goal not found for micro complete: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])
@@ -69,7 +55,7 @@ def micro_complete(
     target_list: List[MicroGoal]
     if phase_name:
         # When a phase is provided we search within it.
-        p = _find_phase(g, phase_name)
+        p = find_phase(g, phase_name)
         if not p:
             logger.error(
                 "Phase not found for micro complete: %s/%s",
@@ -120,7 +106,7 @@ def micro_cancel(
 ) -> None:
     """Cancel a micro-habit without deleting it."""
     # Locate the goal that owns this micro-habit.
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         logger.error("Goal not found for micro cancel: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])
@@ -129,7 +115,7 @@ def micro_cancel(
     target_list: List[MicroGoal]
     if phase_name:
         # Search within the specified phase when provided.
-        p = _find_phase(g, phase_name)
+        p = find_phase(g, phase_name)
         if not p:
             logger.error(
                 "Phase not found for micro cancel: %s/%s",
@@ -198,7 +184,7 @@ def micro_add(
             return
 
     # Ensure the referenced goal exists.
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         logger.error("Goal not found for micro add: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
@@ -213,7 +199,7 @@ def micro_add(
 
     # Phase provided: create or locate the phase first. This lets users add
     # micro-habits to a new phase in a single command.
-    p = _find_phase(g, phase_name)
+    p = find_phase(g, phase_name)
     if not p:
         p = Phase(name=phase_name.strip())
         g.phases.append(p)
@@ -252,7 +238,7 @@ def micro_rm(
 ) -> None:
     """Remove a micro-habit by its name."""
     # Validate and locate the target goal.
-    g = _find_goal(goals, goal_name)
+    g = find_goal(goals, goal_name)
     if not g:
         logger.error("Goal not found for micro rm: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
@@ -261,7 +247,7 @@ def micro_rm(
     target_list: Optional[List[MicroGoal]] = None
     if phase_name:
         # Narrow search to a specific phase when supplied.
-        p = _find_phase(g, phase_name)
+        p = find_phase(g, phase_name)
         if not p:
             logger.error(
                 "Phase not found for micro rm: %s/%s",

--- a/loopbloom/cli/utils.py
+++ b/loopbloom/cli/utils.py
@@ -37,5 +37,7 @@ def find_goal(goals: Iterable[GoalArea], name: str) -> Optional[GoalArea]:
 
 def find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
     """Return the phase within ``goal`` whose name matches ``name``."""
-    return next((p for p in goal.phases if p.name.lower() == name.lower()), None)
-
+    return next(
+        (p for p in goal.phases if p.name.lower() == name.lower()),
+        None,
+    )

--- a/loopbloom/cli/utils.py
+++ b/loopbloom/cli/utils.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from difflib import get_close_matches
-from typing import Iterable
+from typing import Iterable, Optional
+
+from loopbloom.core.models import GoalArea, Phase
 
 import click
 import logging
@@ -26,3 +28,14 @@ def goal_not_found(name: str, goals: Iterable[str]) -> None:
     if match:
         click.echo(f"\nDid you mean \"{match}\"?")  # pragma: no cover
     click.echo("Run 'loopbloom goal list' to see your available goals.")
+
+
+def find_goal(goals: Iterable[GoalArea], name: str) -> Optional[GoalArea]:
+    """Return the goal area whose name matches ``name``."""
+    return next((g for g in goals if g.name.lower() == name.lower()), None)
+
+
+def find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
+    """Return the phase within ``goal`` whose name matches ``name``."""
+    return next((p for p in goal.phases if p.name.lower() == name.lower()), None)
+


### PR DESCRIPTION
## Summary
- add shared `find_goal` and `find_phase` helpers
- use the new helpers in `goal` and `micro` CLI modules

## Testing
- `pytest -q`
- `ruff check . --select=E,F --silent`


------
https://chatgpt.com/codex/tasks/task_e_68667f0301248322b04e8dee40bd945f