### PR TITLE
Centralize application constants

### DIFF
--- a/loopbloom/__main__.py
+++ b/loopbloom/__main__.py
@@ -4,14 +4,12 @@ This module wires together all subcommands and selects the appropriate
 storage backend based on the user's configuration.
 """
 
-import os
 import logging
+import os
 from typing import TYPE_CHECKING, cast
 
 import click
 from click import Command
-
-from loopbloom.logging import setup_logging
 
 from loopbloom.cli.backup import backup  # NEW
 from loopbloom.cli.checkin import checkin
@@ -19,27 +17,19 @@ from loopbloom.cli.config import config  # NEW
 from loopbloom.cli.cope import cope  # NEW
 from loopbloom.cli.export import export  # NEW
 from loopbloom.cli.goal import goal
+from loopbloom.cli.journal import journal
 from loopbloom.cli.micro import micro
+from loopbloom.cli.pause import pause
 from loopbloom.cli.report import report
+from loopbloom.cli.review import review
 from loopbloom.cli.summary import summary
 from loopbloom.cli.tree import tree
-from loopbloom.cli.journal import journal
-from loopbloom.cli.review import review
-from loopbloom.cli.pause import pause
+from loopbloom.constants import JSON_DEFAULT_PATH, SQLITE_DEFAULT_PATH
 from loopbloom.core import config as cfg
+from loopbloom.logging import setup_logging
 from loopbloom.storage.base import Storage
-from loopbloom.storage.json_store import (
-    DEFAULT_PATH as JSON_DEFAULT_PATH,
-)
-from loopbloom.storage.json_store import (
-    JSONStore,
-)
-from loopbloom.storage.sqlite_store import (
-    DEFAULT_PATH as SQLITE_DEFAULT_PATH,
-)
-from loopbloom.storage.sqlite_store import (
-    SQLiteStore,
-)
+from loopbloom.storage.json_store import JSONStore
+from loopbloom.storage.sqlite_store import SQLiteStore
 
 if TYPE_CHECKING:  # pragma: no cover - hints for mypy
     pass

--- a/loopbloom/cli/__init__.py
+++ b/loopbloom/cli/__init__.py
@@ -12,15 +12,7 @@ import click
 
 
 def with_goals(f: Callable[..., Any]) -> Callable[..., Any]:
-    """Loads goals from the store in ``ctx.obj`` before running ``f``.
-
-    The decorated command function receives a mutable list of
-    :class:`~loopbloom.core.models.GoalArea` objects via the ``goals`` keyword
-    argument. After the command completes, any modifications are persisted
-    back to the underlying storage backend. This keeps individual commands
-    simple and avoids repetitive load/save boilerplate across the CLI
-    surface.
-    """
+    """Load goals from ``ctx.obj`` before running ``f``."""
 
     @wraps(f)
     @click.pass_context

--- a/loopbloom/cli/backup.py
+++ b/loopbloom/cli/backup.py
@@ -6,17 +6,16 @@ always mirror the user's active configuration.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-import logging
 
 import click
 
+from loopbloom.constants import JSON_DEFAULT_PATH, SQLITE_DEFAULT_PATH
 from loopbloom.core import config as cfg
-from loopbloom.storage.json_store import DEFAULT_PATH as JSON_DEFAULT_PATH
-from loopbloom.storage.sqlite_store import DEFAULT_PATH as SQLITE_DEFAULT_PATH
 
 logger = logging.getLogger(__name__)
 

--- a/loopbloom/cli/pause.py
+++ b/loopbloom/cli/pause.py
@@ -1,9 +1,10 @@
+"""Temporarily disable notifications for goals."""
+
 from datetime import date, timedelta
 
 import click
 
 from loopbloom.core import config as cfg
-
 
 _DEF_HELP = "Pause notifications globally or for a specific goal."
 
@@ -13,7 +14,7 @@ def _parse_duration(text: str) -> timedelta | None:
     if not text:
         return None
     num = "".join(ch for ch in text if ch.isdigit())
-    unit = text[len(num):]
+    unit = text[len(num) :]
     if not num or unit not in {"d", "w"}:
         return None
     days = int(num) * (7 if unit == "w" else 1)

--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -16,6 +16,7 @@ from rich.progress_bar import ProgressBar
 from rich.table import Table
 
 from loopbloom.cli import with_goals
+from loopbloom.constants import DEFAULT_TIMEFRAME
 from loopbloom.core.models import GoalArea, MicroGoal
 
 console = Console()
@@ -71,10 +72,7 @@ def _calendar_heatmap(goals: List[GoalArea]) -> None:
                 stats[ci.date.day] = (succ, tot)
 
     weeks = cal.monthdayscalendar(today.year, today.month)
-    title = (
-        "LoopBloom Check-in Heatmap – "
-        f"{month_name[today.month]} {today.year}"
-    )
+    title = "LoopBloom Check-in Heatmap – " f"{month_name[today.month]} {today.year}"
     console.print(f"[bold]{title}[/bold]")
     for week in weeks:
         line = ""
@@ -117,17 +115,20 @@ def _success_bars(goals: List[GoalArea]) -> None:
 
 
 def _line_chart(goals: List[GoalArea]) -> None:
-    """Show a line chart of daily success rates over the last 30 days."""
+    """Show a line chart of daily success rates.
+
+    The chart spans the last ``DEFAULT_TIMEFRAME`` days.
+    """
     # ``plotext`` is a lightweight plotting library used only for this view.
     # It's an optional dependency so ``report --mode line`` can be skipped if
     # the library isn't installed.
     import plotext as plt
 
     today = date.today()
-    start = today - timedelta(days=29)
+    start = today - timedelta(days=DEFAULT_TIMEFRAME - 1)
 
     rates: list[float] = []
-    for i in range(30):
+    for i in range(DEFAULT_TIMEFRAME):
         day = start + timedelta(days=i)
         successes = 0
         total = 0
@@ -140,11 +141,11 @@ def _line_chart(goals: List[GoalArea]) -> None:
         rate = (successes / total) * 100 if total else 0
         rates.append(rate)
 
-    x = list(range(30))
+    x = list(range(DEFAULT_TIMEFRAME))
     plt.clear_data()
     plt.clear_figure()
     plt.plot(x, rates)
-    plt.title("Success Rate (Last 30 Days)")
+    plt.title(f"Success Rate (Last {DEFAULT_TIMEFRAME} Days)")
     plt.ylim(0, 100)
     plt.yticks([0, 25, 50, 75, 100])
     plt.show()

--- a/loopbloom/cli/review.py
+++ b/loopbloom/cli/review.py
@@ -1,3 +1,5 @@
+"""Capture brief reflections on progress."""
+
 from __future__ import annotations
 
 import click

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -7,17 +7,18 @@ checks whether it should be advanced.
 
 from __future__ import annotations
 
+import logging
 from datetime import date, timedelta
 from typing import List
 
 import click
-import logging
 from rich.console import Console, Group
-from rich.table import Table
 from rich.progress_bar import ProgressBar
+from rich.table import Table
 
 from loopbloom.cli import with_goals
 from loopbloom.cli.utils import goal_not_found
+from loopbloom.constants import WINDOW_DEFAULT
 from loopbloom.core import config as cfg
 from loopbloom.core.models import GoalArea
 from loopbloom.core.progression import should_advance
@@ -25,8 +26,6 @@ from loopbloom.core.progression import should_advance
 console = Console()
 
 logger = logging.getLogger(__name__)
-
-WINDOW_DEFAULT = 14  # days
 
 
 @click.command(

--- a/loopbloom/constants.py
+++ b/loopbloom/constants.py
@@ -1,0 +1,36 @@
+"""Central location for application-wide default values."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from loopbloom.core.config import APP_DIR
+
+# Numeric defaults used across commands and services
+WINDOW_DEFAULT = 14  # days considered when summarising progress
+THRESHOLD_DEFAULT = 0.80  # 80 % success required for advancement
+DEFAULT_TIMEFRAME = 30  # days displayed in report line charts
+
+# Default storage locations
+JSON_DEFAULT_PATH = Path(os.getenv("LOOPBLOOM_DATA_PATH", APP_DIR / "data.json"))
+JSON_DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+SQLITE_DEFAULT_PATH = Path(os.getenv("LOOPBLOOM_SQLITE_PATH", APP_DIR / "data.db"))
+SQLITE_DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+# Journal and review file paths
+JOURNAL_PATH = APP_DIR / "journal.json"
+JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+REVIEW_PATH = APP_DIR / "reviews.json"
+REVIEW_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+# Bundled data directory and assets
+BASE_DIR = Path(__file__).resolve().parent
+DATA_DIR = BASE_DIR / "data"
+TALKS_PATH = DATA_DIR / "default_talks.json"
+COPING_DIR = DATA_DIR / "coping"
+
+# Generic fallback pep talk when no templates are available
+PEP_TALK_FALLBACK = "Great job!"

--- a/loopbloom/core/coping.py
+++ b/loopbloom/core/coping.py
@@ -12,8 +12,7 @@ from typing import Any, Dict, List
 
 import yaml
 
-# Directory containing YAML coping plans bundled with the package.
-COPING_DIR = Path(__file__).resolve().parent.parent / "data" / "coping"
+from loopbloom.constants import COPING_DIR
 
 
 class CopingPlanError(RuntimeError):

--- a/loopbloom/core/journal.py
+++ b/loopbloom/core/journal.py
@@ -1,16 +1,15 @@
+"""Simple JSON-based journal entries."""
+
 from __future__ import annotations
 
-from datetime import datetime
 import json
+from datetime import datetime
 from typing import List
 
 from pydantic import BaseModel, Field
 from pydantic.json import pydantic_encoder
 
-from loopbloom.core.config import APP_DIR
-
-JOURNAL_PATH = APP_DIR / "journal.json"
-JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+from loopbloom.constants import JOURNAL_PATH
 
 
 class JournalEntry(BaseModel):

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -9,12 +9,9 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import List
 
+from loopbloom.constants import THRESHOLD_DEFAULT, WINDOW_DEFAULT
 from loopbloom.core import config as cfg
 from loopbloom.core.models import Checkin, MicroGoal
-
-# Default history window and success rate threshold for progression logic.
-WINDOW_DEFAULT = 14  # days to consider
-THRESHOLD_DEFAULT = 0.80  # 80 % success required
 
 
 def _recent_checkins(checkins: List[Checkin], window: int) -> List[Checkin]:

--- a/loopbloom/core/review.py
+++ b/loopbloom/core/review.py
@@ -1,16 +1,15 @@
+"""User reflection entry storage."""
+
 from __future__ import annotations
 
-from datetime import datetime
 import json
+from datetime import datetime
 from typing import List
 
 from pydantic import BaseModel, Field
 from pydantic.json import pydantic_encoder
 
-from loopbloom.core.config import APP_DIR
-
-REVIEW_PATH = APP_DIR / "reviews.json"
-REVIEW_PATH.parent.mkdir(parents=True, exist_ok=True)
+from loopbloom.constants import REVIEW_PATH
 
 
 class ReviewEntry(BaseModel):

--- a/loopbloom/core/talks.py
+++ b/loopbloom/core/talks.py
@@ -8,13 +8,9 @@ from __future__ import annotations
 
 import json
 import random
-from pathlib import Path
 from typing import Dict, List
 
-# Directory containing bundled data files such as the default pep talks.
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
-# JSON file with two lists of pep-talk snippets keyed by mood (success/skip).
-TALKS_PATH = DATA_DIR / "default_talks.json"
+from loopbloom.constants import PEP_TALK_FALLBACK, TALKS_PATH
 
 
 class TalkPool:
@@ -39,6 +35,6 @@ class TalkPool:
         pool = cls._load().get(mood, [])
         if not pool:
             # Default message when no templates are available.
-            return "Great job!"
+            return PEP_TALK_FALLBACK
         # ``random.choice`` provides an even distribution across messages.
         return random.choice(pool)

--- a/loopbloom/logging.py
+++ b/loopbloom/logging.py
@@ -1,3 +1,5 @@
+"""Logging configuration helpers."""
+
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -12,9 +14,7 @@ def setup_logging(level: int = logging.INFO) -> None:
     log_file = log_dir / "loopbloom.log"
 
     handler = RotatingFileHandler(log_file, maxBytes=1_000_000, backupCount=3)
-    formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-    )
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
     handler.setFormatter(formatter)
 
     root_logger = logging.getLogger()

--- a/loopbloom/storage/json_store.py
+++ b/loopbloom/storage/json_store.py
@@ -7,27 +7,20 @@ easy to inspect and backup.
 from __future__ import annotations
 
 import json
-import os
+import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import ContextManager, List
-import logging
 
 from pydantic.json import pydantic_encoder
 
+from loopbloom.constants import JSON_DEFAULT_PATH
 from loopbloom.core.models import GoalArea
-from loopbloom.core.config import APP_DIR
 from loopbloom.storage.base import Storage, StorageError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_PATH = Path(
-    os.getenv("LOOPBLOOM_DATA_PATH", APP_DIR / "data.json")
-)
-# Ensure the data directory exists before any read/write operations.
-# Users may override this path via the ``LOOPBLOOM_DATA_PATH`` environment
-# variable for ad-hoc experiments or testing.
-DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+DEFAULT_PATH = JSON_DEFAULT_PATH
 
 
 class JSONStore(Storage):
@@ -89,5 +82,6 @@ class JSONStore(Storage):
     def lock(self) -> ContextManager[None]:
         """Return a no-op context manager for compatibility."""
         from contextlib import nullcontext
+
         # JSON files don't need locking in single-user mode.
         return nullcontext()

--- a/loopbloom/storage/sqlite_store.py
+++ b/loopbloom/storage/sqlite_store.py
@@ -1,10 +1,11 @@
-"""SQLite implementation of :class:`~loopbloom.storage.base.Storage` using
-SQLAlchemy Core for lightweight database access."""
+"""SQLite implementation of :class:`~loopbloom.storage.base.Storage`.
+
+Uses SQLAlchemy Core for lightweight database access.
+"""
 
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import List
 
@@ -22,16 +23,11 @@ from sqlalchemy import (
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
+from loopbloom.constants import SQLITE_DEFAULT_PATH
 from loopbloom.core.models import GoalArea
 from loopbloom.storage.base import Storage, StorageError
-from loopbloom.core.config import APP_DIR
 
-DEFAULT_PATH = Path(
-    os.getenv("LOOPBLOOM_SQLITE_PATH", APP_DIR / "data.db")
-)
-# Ensure parent directory exists for the database file.
-# ``LOOPBLOOM_SQLITE_PATH`` can relocate the DB for testing or advanced usage.
-DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+DEFAULT_PATH = SQLITE_DEFAULT_PATH
 
 metadata = MetaData()
 


### PR DESCRIPTION
## Summary
- centralize default constants in `loopbloom/constants.py`
- update modules to import and use centralized values
- adjust docstrings and imports to satisfy linters

## Testing
- `ruff check loopbloom`
- `black --check loopbloom/__main__.py loopbloom/cli/__init__.py loopbloom/cli/backup.py loopbloom/cli/pause.py loopbloom/cli/report.py loopbloom/cli/review.py loopbloom/cli/summary.py loopbloom/core/coping.py loopbloom/core/journal.py loopbloom/core/progression.py loopbloom/core/review.py loopbloom/core/talks.py loopbloom/logging.py loopbloom/storage/json_store.py loopbloom/storage/sqlite_store.py loopbloom/constants.py`
- `mypy loopbloom` *(fails: "tomli_w" missing)*
- `pytest -q` *(fails: missing dependencies like `tomli_w`, `rich`)*

------
https://chatgpt.com/codex/tasks/task_e_6866fc6e3fc48322a8c2a94ff9228b32