### PR TITLE
Introduce progression service

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -15,6 +15,7 @@ from loopbloom.cli.utils import goal_not_found
 from loopbloom.cli.interactive import choose_from
 from loopbloom.core.models import Checkin, GoalArea
 from loopbloom.core.talks import TalkPool
+from loopbloom.services.progression import ProgressionService
 
 logger = logging.getLogger(__name__)
 
@@ -98,3 +99,21 @@ def checkin(
     # Notification style (desktop or terminal) comes from user config.
     notify_mode = cfg.load().get("notify", "terminal")
     notifier.send("LoopBloom Check-in", talk, mode=notify_mode, goal=goal.name)
+
+    progression_service = ProgressionService()
+    should_progress, reasons = progression_service.check_progression(goal)
+
+    if should_progress:
+        print(
+            "\n[bold green]Congratulations! You've made enough progress to "
+            "advance to the next phase.[/bold green]"
+        )
+        for reason in reasons:
+            print(f"- {reason}")
+    else:
+        print(
+            "\n[bold]Keep up the great work! You're making steady "
+            "progress.[/bold]"
+        )
+        for reason in reasons:
+            print(f"- {reason}")

--- a/loopbloom/services/progression.py
+++ b/loopbloom/services/progression.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Business logic wrapper for goal progression."""
+
+from loopbloom.core.models import GoalArea
+from loopbloom.core.progression import should_advance, get_progression_reasons
+
+
+class ProgressionService:
+    """Handles the business logic for goal progression."""
+
+    @staticmethod
+    def check_progression(goal: GoalArea) -> tuple[bool, list[str]]:
+        """Return whether ``goal`` should advance to the next micro-habit."""
+        micro = goal.get_active_micro_goal()
+        if micro is None:
+            return False, ["No active micro-goal."]
+        should_progress = should_advance(micro)
+        reasons = get_progression_reasons(micro)
+        return should_progress, reasons


### PR DESCRIPTION
## Summary
- add `ProgressionService` for encapsulating advancement logic
- extend `should_advance` module with `get_progression_reasons`
- integrate progression checks in `checkin` command

## Testing
- `poetry run ./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68676391e630832298570b069f105647