### PR TITLE
Ensure CI hooks pass

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -112,8 +112,7 @@ def checkin(
             print(f"- {reason}")
     else:
         print(
-            "\n[bold]Keep up the great work! You're making steady "
-            "progress.[/bold]"
+            "\n[bold]Keep up the great work! You're making steady " "progress.[/bold]"
         )
         for reason in reasons:
             print(f"- {reason}")

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -111,8 +111,12 @@ def checkin(
         for reason in reasons:
             print(f"- {reason}")
     else:
-        print(
-            "\n[bold]Keep up the great work! You're making steady " "progress.[/bold]"
+        # fmt: off
+        progress_msg = (
+            "\n[bold]Keep up the great work! You're making steady "
+            "progress.[/bold]"
         )
+        # fmt: on
+        print(progress_msg)
         for reason in reasons:
             print(f"- {reason}")

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -112,7 +112,8 @@ def checkin(
             print(f"- {reason}")
     else:
         print(
-            "\n[bold]Keep up the great work! You're making steady " "progress.[/bold]"
+            "\n[bold]Keep up the great work! You're making steady "
+            "progress.[/bold]"
         )
         for reason in reasons:
             print(f"- {reason}")

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -4,15 +4,15 @@ This subcommand records progress for the active micro-habit under a goal
 and offers a small pep talk to keep momentum going.
 """
 
+import logging
 from typing import List, Optional
 
 import click
 from rich import print
-import logging
 
 from loopbloom.cli import with_goals
-from loopbloom.cli.utils import goal_not_found
 from loopbloom.cli.interactive import choose_from
+from loopbloom.cli.utils import goal_not_found
 from loopbloom.core.models import Checkin, GoalArea
 from loopbloom.core.talks import TalkPool
 from loopbloom.services.progression import ProgressionService
@@ -112,8 +112,7 @@ def checkin(
             print(f"- {reason}")
     else:
         print(
-            "\n[bold]Keep up the great work! You're making steady "
-            "progress.[/bold]"
+            "\n[bold]Keep up the great work! You're making steady " "progress.[/bold]"
         )
         for reason in reasons:
             print(f"- {reason}")

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -85,7 +85,9 @@ def get_progression_reasons(
     recent = _recent_checkins(micro.checkins, window)
     successes = sum(ci.success for ci in recent)
     reasons: list[str] = []
-    reasons.append(f"{successes} successes in last {len(recent)}/{window} days")
+    reasons.append(
+        f"{successes} successes in last {len(recent)}/{window} days"
+    )
     if len(recent) < window:
         remaining = window - len(recent)
         reasons.append(f"{remaining} more day(s) needed for full window")

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -85,9 +85,7 @@ def get_progression_reasons(
     recent = _recent_checkins(micro.checkins, window)
     successes = sum(ci.success for ci in recent)
     reasons: list[str] = []
-    reasons.append(
-        f"{successes} successes in last {len(recent)}/{window} days"
-    )
+    reasons.append(f"{successes} successes in last {len(recent)}/{window} days")
     if len(recent) < window:
         remaining = window - len(recent)
         reasons.append(f"{remaining} more day(s) needed for full window")

--- a/loopbloom/services/progression.py
+++ b/loopbloom/services/progression.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
 """Business logic wrapper for goal progression."""
 
+from __future__ import annotations
+
 from loopbloom.core.models import GoalArea
-from loopbloom.core.progression import should_advance, get_progression_reasons
+from loopbloom.core.progression import get_progression_reasons, should_advance
 
 
 class ProgressionService:


### PR DESCRIPTION
## Summary
- reorder imports in `checkin`
- format `get_progression_reasons`
- put module docstring at top of `ProgressionService`

## Testing
- `pre-commit run --files loopbloom/cli/checkin.py loopbloom/core/progression.py loopbloom/services/progression.py loopbloom/services/__init__.py --hook-stage manual`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686858546aa883229e7648522a82e23f