### PR TITLE
Add notes editor commands

### DIFF
--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -1,13 +1,19 @@
 """LoopBloom CLI: goal, phase, and micro-habit CRUD."""
 
+import logging
 from typing import List, Optional
 
 import click
-import logging
 
 from loopbloom.cli import with_goals
-from loopbloom.cli.utils import goal_not_found, find_goal, find_phase
 from loopbloom.cli.interactive import choose_from
+from loopbloom.cli.utils import (
+    find_goal,
+    find_phase,
+    get_goal_from_name,
+    goal_not_found,
+    save_goal,
+)
 from loopbloom.core.models import GoalArea, MicroGoal, Phase
 
 logger = logging.getLogger(__name__)
@@ -67,9 +73,7 @@ def goal_rm(
     if name is None:
         if not goals:
             logger.info("No goals to remove")
-            click.echo(
-                "[italic]No goals – nothing to remove."
-            )  # pragma: no cover
+            click.echo("[italic]No goals – nothing to remove.")  # pragma: no cover
             return  # pragma: no cover
         click.echo("Which goal do you want to delete?")  # pragma: no cover
         selected = choose_from(
@@ -96,23 +100,21 @@ def goal_rm(
     click.echo(f"[green]Deleted goal:[/] {name}")
 
 
-@goal.command(name="notes", help="View or set notes for a goal.")
+@goal.command(name="notes", help="View and edit goal notes in $EDITOR.")
 @click.argument("name")
-@click.argument("text", required=False)
-@with_goals
-def goal_notes(name: str, text: Optional[str], goals: List[GoalArea]) -> None:
-    """Display or update notes for ``name``."""
-    g = find_goal(goals, name)
-    if not g:
-        logger.error("Goal not found for notes: %s", name)
-        goal_not_found(name, [x.name for x in goals])
-        return
-    if text is None:
-        click.echo(g.notes or "")
-    else:
-        g.notes = text.strip() or None
-        logger.info("Saved notes for goal %s", name)
-        click.echo(f"[green]Saved notes for '{name}'.")
+@click.pass_context
+def goal_notes(ctx: click.Context, name: str) -> None:
+    """Open ``name``'s notes in the user's editor."""
+    goal = get_goal_from_name(name)
+    if not goal:
+        goal_not_found(name, [])
+        raise click.Abort()
+
+    edited = click.edit(goal.notes or "")
+    if edited is not None:
+        goal.notes = edited.strip()
+        save_goal(goal)
+        click.echo(f"[green]Notes for goal '{name}' updated.")
 
 
 # Phase commands
@@ -145,9 +147,7 @@ def phase_add(
         names = [g.name for g in goals]
         if not names:
             logger.error("No goals for phase addition")
-            click.echo(
-                "[red]No goals – use `loopbloom goal add`."
-            )  # pragma: no cover
+            click.echo("[red]No goals – use `loopbloom goal add`.")  # pragma: no cover
             return  # pragma: no cover
         click.echo("Select goal for new phase:")  # pragma: no cover
         goal_name = choose_from(
@@ -192,9 +192,7 @@ def phase_rm(
         names = [g.name for g in goals]
         if not names:
             logger.error("No goals for phase removal")
-            click.echo(
-                "[red]No goals – use `loopbloom goal add`."
-            )  # pragma: no cover
+            click.echo("[red]No goals – use `loopbloom goal add`.")  # pragma: no cover
             return  # pragma: no cover
         click.echo("Select goal:")  # pragma: no cover
         goal_name = choose_from(
@@ -215,9 +213,7 @@ def phase_rm(
         options = [p.name for p in g.phases]
         if not options:
             logger.error("No phases in goal %s", goal_name)
-            click.echo(
-                "[red]No phases found for this goal."
-            )  # pragma: no cover
+            click.echo("[red]No phases found for this goal.")  # pragma: no cover
             return  # pragma: no cover
         click.echo("Select phase to delete:")  # pragma: no cover
         phase_name = choose_from(
@@ -244,36 +240,26 @@ def phase_rm(
     click.echo(f"[green]Deleted phase '{phase_name}' from {goal_name}")
 
 
-@phase.command(name="notes", help="View or set notes for a phase.")
+@phase.command(name="notes", help="View and edit notes for a phase in $EDITOR.")
 @click.argument("goal_name")
 @click.argument("phase_name")
-@click.argument("text", required=False)
-@with_goals
-def phase_notes(
-    goal_name: str,
-    phase_name: str,
-    text: Optional[str],
-    goals: List[GoalArea],
-) -> None:
-    """Display or update notes for a phase."""
-    g = find_goal(goals, goal_name)
-    if not g:
-        logger.error("Goal not found for phase notes: %s", goal_name)
-        goal_not_found(goal_name, [x.name for x in goals])
-        return
-    p = find_phase(g, phase_name)
-    if not p:
-        logger.error("Phase not found for notes: %s/%s", goal_name, phase_name)
+@click.pass_context
+def phase_notes(ctx: click.Context, goal_name: str, phase_name: str) -> None:
+    """Open notes for ``phase_name`` under ``goal_name`` in the editor."""
+    goal = get_goal_from_name(goal_name)
+    if not goal:
+        goal_not_found(goal_name, [])
+        raise click.Abort()
+    phase = find_phase(goal, phase_name)
+    if not phase:
         click.echo("[red]Phase not found.")
-        return
-    if text is None:
-        click.echo(p.notes or "")
-    else:
-        p.notes = text.strip() or None
-        logger.info("Saved notes for phase %s under %s", phase_name, goal_name)
-        click.echo(
-            f"[green]Saved notes for phase '{phase_name}' under {goal_name}."
-        )
+        raise click.Abort()
+
+    edited = click.edit(phase.notes or "")
+    if edited is not None:
+        phase.notes = edited.strip()
+        save_goal(goal)
+        click.echo(f"[green]Notes for phase '{phase_name}' under {goal_name} updated.")
 
 
 @goal.command(

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -73,7 +73,8 @@ def goal_rm(
     if name is None:
         if not goals:
             logger.info("No goals to remove")
-            click.echo("[italic]No goals – nothing to remove.")  # pragma: no cover
+            msg = "[italic]No goals – nothing to remove."
+            click.echo(msg)  # pragma: no cover
             return  # pragma: no cover
         click.echo("Which goal do you want to delete?")  # pragma: no cover
         selected = choose_from(
@@ -111,7 +112,9 @@ def goal_notes(ctx: click.Context, name: str) -> None:
         raise click.Abort()
 
     edited = click.edit(goal.notes or "")
-    if edited is not None:
+    if edited is None:
+        click.echo(goal.notes or "")
+    else:
         goal.notes = edited.strip()
         save_goal(goal)
         click.echo(f"[green]Notes for goal '{name}' updated.")
@@ -147,7 +150,8 @@ def phase_add(
         names = [g.name for g in goals]
         if not names:
             logger.error("No goals for phase addition")
-            click.echo("[red]No goals – use `loopbloom goal add`.")  # pragma: no cover
+            msg = "[red]No goals – use `loopbloom goal add`."
+            click.echo(msg)  # pragma: no cover
             return  # pragma: no cover
         click.echo("Select goal for new phase:")  # pragma: no cover
         goal_name = choose_from(
@@ -192,7 +196,8 @@ def phase_rm(
         names = [g.name for g in goals]
         if not names:
             logger.error("No goals for phase removal")
-            click.echo("[red]No goals – use `loopbloom goal add`.")  # pragma: no cover
+            msg = "[red]No goals – use `loopbloom goal add`."
+            click.echo(msg)  # pragma: no cover
             return  # pragma: no cover
         click.echo("Select goal:")  # pragma: no cover
         goal_name = choose_from(
@@ -213,7 +218,8 @@ def phase_rm(
         options = [p.name for p in g.phases]
         if not options:
             logger.error("No phases in goal %s", goal_name)
-            click.echo("[red]No phases found for this goal.")  # pragma: no cover
+            msg = "[red]No phases found for this goal."
+            click.echo(msg)  # pragma: no cover
             return  # pragma: no cover
         click.echo("Select phase to delete:")  # pragma: no cover
         phase_name = choose_from(
@@ -240,7 +246,10 @@ def phase_rm(
     click.echo(f"[green]Deleted phase '{phase_name}' from {goal_name}")
 
 
-@phase.command(name="notes", help="View and edit notes for a phase in $EDITOR.")
+@phase.command(
+    name="notes",
+    help="View and edit notes for a phase in $EDITOR.",
+)
 @click.argument("goal_name")
 @click.argument("phase_name")
 @click.pass_context
@@ -256,10 +265,16 @@ def phase_notes(ctx: click.Context, goal_name: str, phase_name: str) -> None:
         raise click.Abort()
 
     edited = click.edit(phase.notes or "")
-    if edited is not None:
+    if edited is None:
+        click.echo(phase.notes or "")
+    else:
         phase.notes = edited.strip()
         save_goal(goal)
-        click.echo(f"[green]Notes for phase '{phase_name}' under {goal_name} updated.")
+        msg = "[green]Notes for phase '{}' under {} updated.".format(
+            phase_name,
+            goal_name,
+        )
+        click.echo(msg)
 
 
 @goal.command(

--- a/loopbloom/cli/utils.py
+++ b/loopbloom/cli/utils.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from difflib import get_close_matches
 from typing import Iterable, Optional
 
-from loopbloom.core.models import GoalArea, Phase
-
 import click
-import logging
+
+from loopbloom.core.models import GoalArea, Phase
 
 
 def suggest_name(name: str, options: Iterable[str]) -> str | None:
@@ -22,11 +22,11 @@ def goal_not_found(name: str, goals: Iterable[str]) -> None:
     """Print helpful message when a goal is missing."""
     logger = logging.getLogger(__name__)
     logger.error("Goal not found: %s", name)
-    click.echo(f"[red]Goal not found: \"{name}\".[/red]")
+    click.echo(f'[red]Goal not found: "{name}".[/red]')
     # Suggest the closest existing goal to reduce user confusion.
     match = suggest_name(name, goals)
     if match:
-        click.echo(f"\nDid you mean \"{match}\"?")  # pragma: no cover
+        click.echo(f'\nDid you mean "{match}"?')  # pragma: no cover
     click.echo("Run 'loopbloom goal list' to see your available goals.")
 
 
@@ -41,3 +41,16 @@ def find_phase(goal: GoalArea, name: str) -> Optional[Phase]:
         (p for p in goal.phases if p.name.lower() == name.lower()),
         None,
     )
+
+
+def get_goal_from_name(name: str) -> Optional[GoalArea]:
+    """Load and return the goal matching ``name`` from the current store."""
+    store = click.get_current_context().obj
+    goals = store.load()
+    return next((g for g in goals if g.name.lower() == name.lower()), None)
+
+
+def save_goal(goal: GoalArea) -> None:
+    """Persist ``goal`` using the current store."""
+    store = click.get_current_context().obj
+    store.save_goal_area(goal)

--- a/tests/integration/test_goal_cli.py
+++ b/tests/integration/test_goal_cli.py
@@ -19,6 +19,7 @@ def test_goal_phase_micro_crud(tmp_path):
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     # Add a goal
@@ -84,6 +85,7 @@ def test_goal_rm_missing(tmp_path) -> None:
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     res = runner.invoke(cli, ["goal", "rm", "Ghost", "--yes"], env=env)
@@ -99,6 +101,7 @@ def test_phase_add_missing_goal(tmp_path) -> None:
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     res = runner.invoke(
@@ -118,6 +121,7 @@ def test_phase_rm(tmp_path) -> None:
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     runner.invoke(cli, ["goal", "add", "Exercise"], env=env)
@@ -143,6 +147,7 @@ def test_micro_add_creates_phase(tmp_path) -> None:
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
 
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     runner.invoke(cli, ["goal", "add", "Exercise"], env=env)
@@ -175,40 +180,57 @@ def test_goal_and_phase_notes(tmp_path) -> None:
 
     os.environ["LOOPBLOOM_DATA_PATH"] = str(data_file)
     from loopbloom import __main__ as main
+
     cli = main.cli
 
     # Goal notes
+    runner.invoke(cli, ["goal", "add", "Exercise"], env=env)
+    script = tmp_path / "edit_goal.sh"
+    script.write_text("#!/bin/sh\necho 'start' > \"$1\"\n")
+    script.chmod(0o755)
     runner.invoke(
-        cli,
-        ["goal", "add", "Exercise", "--notes", "start"],
-        env=env,
+        cli, ["goal", "notes", "Exercise"], env={**env, "EDITOR": str(script)}
     )
-    res = runner.invoke(cli, ["goal", "notes", "Exercise"], env=env)
+    res = runner.invoke(
+        cli, ["goal", "notes", "Exercise"], env={**env, "EDITOR": "cat"}
+    )
     assert "start" in res.output
-    runner.invoke(cli, ["goal", "notes", "Exercise", "updated"], env=env)
-    res = runner.invoke(cli, ["goal", "notes", "Exercise"], env=env)
+
+    script.write_text("#!/bin/sh\necho 'updated' > \"$1\"\n")
+    runner.invoke(
+        cli, ["goal", "notes", "Exercise"], env={**env, "EDITOR": str(script)}
+    )
+    res = runner.invoke(
+        cli, ["goal", "notes", "Exercise"], env={**env, "EDITOR": "cat"}
+    )
     assert "updated" in res.output
 
     # Phase notes
+    runner.invoke(cli, ["goal", "phase", "add", "Exercise", "Base"], env=env)
+    script_p = tmp_path / "edit_phase.sh"
+    script_p.write_text("#!/bin/sh\necho 'plan' > \"$1\"\n")
+    script_p.chmod(0o755)
     runner.invoke(
         cli,
-        ["goal", "phase", "add", "Exercise", "Base", "--notes", "plan"],
-        env=env,
+        ["goal", "phase", "notes", "Exercise", "Base"],
+        env={**env, "EDITOR": str(script_p)},
     )
     res = runner.invoke(
         cli,
         ["goal", "phase", "notes", "Exercise", "Base"],
-        env=env,
+        env={**env, "EDITOR": "cat"},
     )
     assert "plan" in res.output
+
+    script_p.write_text("#!/bin/sh\necho 'do it' > \"$1\"\n")
     runner.invoke(
         cli,
-        ["goal", "phase", "notes", "Exercise", "Base", "do it"],
-        env=env,
+        ["goal", "phase", "notes", "Exercise", "Base"],
+        env={**env, "EDITOR": str(script_p)},
     )
     res = runner.invoke(
         cli,
         ["goal", "phase", "notes", "Exercise", "Base"],
-        env=env,
+        env={**env, "EDITOR": "cat"},
     )
     assert "do it" in res.output


### PR DESCRIPTION
## Summary
- open goal and phase notes in the default text editor
- add helper utils to load and save individual goals
- update integration test for new editor-based notes commands

## Testing
- `ruff check loopbloom/cli/utils.py loopbloom/cli/goal.py tests/integration/test_goal_cli.py`
- `black loopbloom/cli/utils.py loopbloom/cli/goal.py tests/integration/test_goal_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6868610101748322a03aee40f310c177