### PR TITLE
Add configurable progression strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,12 @@ flowchart TD
     Progression -->|otherwise| CompassionateNudge
 ```
 
-Parameters `threshold` and `window` are user-configurable.
-When omitted by commands, the progression rule reads these values from
-`~/.config/loopbloom/config.toml`.
+Parameters `threshold` and `window` are user configurable.
+Users may also choose how progress is evaluated using
+`advance.strategy` (`ratio` or `streak`). When the `streak` strategy is
+selected, the `advance.streak_to_advance` setting determines how many
+consecutive successes are required. When omitted by commands, the
+progression rule reads these values from `~/.config/loopbloom/config.toml`.
 
 <a id="notifications"></a>
 

--- a/tests/unit/test_config_module.py
+++ b/tests/unit/test_config_module.py
@@ -61,3 +61,23 @@ def test_cli_get_missing_key(tmp_path, monkeypatch) -> None:
     runner = CliRunner()
     result = runner.invoke(cli_cfg._get, ["nonexistent.key"])
     assert "[red]Key not found." in result.output
+
+
+def test_cli_set_progression_strategy(tmp_path, monkeypatch) -> None:
+    """Setting progression strategy validates allowed values."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    import importlib
+    import loopbloom.core.config as cfg_mod
+    import loopbloom.cli.config as cli_cfg
+
+    importlib.reload(cfg_mod)
+    importlib.reload(cli_cfg)
+
+    runner = CliRunner()
+    res = runner.invoke(cli_cfg._set, ["advance.strategy", "streak"])
+    assert "Saved." in res.output
+    assert cfg_mod.load()["advance"]["strategy"] == "streak"
+
+    bad = runner.invoke(cli_cfg._set, ["advance.strategy", "bogus"])
+    assert "Invalid progression strategy" in bad.output


### PR DESCRIPTION
## Summary
- allow progression strategy configuration with streak support
- validate strategy via CLI when setting config values
- implement streak-based advancement logic
- test new strategy behaviour and CLI config handling

## Testing
- `poetry run ./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_686868943918832286091cfcec4c3d44