### PR TITLE
Add streak-based progression

### DIFF
--- a/loopbloom/cli/config.py
+++ b/loopbloom/cli/config.py
@@ -76,6 +76,12 @@ def _set(key: str, value: str) -> None:
                 cast = lower == "true"
             else:
                 cast = value
+    if key == "advance.strategy":
+        lower = str(cast).lower()
+        if lower not in ("ratio", "streak"):
+            click.echo("[red]Invalid strategy. Use 'ratio' or 'streak'.")
+            return
+        cast = lower
     # Assign the converted value and persist.
     d[parts[-1]] = cast
     cfg.save(conf)

--- a/tests/unit/test_progression.py
+++ b/tests/unit/test_progression.py
@@ -55,3 +55,27 @@ def test_microgoal_custom_criteria(monkeypatch) -> None:
         lambda: {"advance": {"threshold": 0.99, "window": 14}},
     )
     assert should_advance(mg)
+
+
+def test_should_advance_streak_strategy(monkeypatch) -> None:
+    """Streak strategy uses trailing successes."""
+    mg = MicroGoal(name="Streak")
+    for i in range(7):
+        mg.checkins.append(Checkin(date=TODAY - timedelta(days=i), success=True))
+    monkeypatch.setattr(
+        "loopbloom.core.config.load",
+        lambda: {"advance": {"strategy": "streak", "streak_to_advance": 5}},
+    )
+    assert should_advance(mg)
+
+
+def test_streak_strategy_insufficient(monkeypatch) -> None:
+    """Fails when streak shorter than required."""
+    mg = MicroGoal(name="Short")
+    for i in range(3):
+        mg.checkins.append(Checkin(date=TODAY - timedelta(days=i), success=True))
+    monkeypatch.setattr(
+        "loopbloom.core.config.load",
+        lambda: {"advance": {"strategy": "streak", "streak_to_advance": 5}},
+    )
+    assert not should_advance(mg)


### PR DESCRIPTION
## Summary
- extend user config with progression strategy settings
- implement streak progression logic
- validate strategy in CLI config
- support ratio and streak modes in tests

## Testing
- `./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68686d77c1dc832285bd9ec59bf28496