### PR TITLE
Centralize constants in new module

### DIFF
--- a/loopbloom/cli/cope.py
+++ b/loopbloom/cli/cope.py
@@ -10,7 +10,8 @@ import logging
 import click
 import yaml
 
-from loopbloom.core.coping import COPING_DIR, PlanRepository, run_plan
+from loopbloom.constants import COPING_DIR
+from loopbloom.core.coping import PlanRepository, run_plan
 
 logger = logging.getLogger(__name__)
 

--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -16,6 +16,7 @@ from rich.progress_bar import ProgressBar
 from rich.table import Table
 
 from loopbloom.cli import with_goals
+from loopbloom.constants import DEFAULT_TIMEFRAME
 from loopbloom.core.models import GoalArea, MicroGoal
 
 console = Console()
@@ -114,17 +115,17 @@ def _success_bars(goals: List[GoalArea]) -> None:
 
 
 def _line_chart(goals: List[GoalArea]) -> None:
-    """Show a line chart of daily success rates over the last 30 days."""
+    """Show a line chart of daily success rates."""
     # ``plotext`` is a lightweight plotting library used only for this view.
     # It's an optional dependency so ``report --mode line`` can be skipped if
     # the library isn't installed.
     import plotext as plt
 
     today = date.today()
-    start = today - timedelta(days=29)
+    start = today - timedelta(days=DEFAULT_TIMEFRAME - 1)
 
     rates: list[float] = []
-    for i in range(30):
+    for i in range(DEFAULT_TIMEFRAME):
         day = start + timedelta(days=i)
         successes = 0
         total = 0
@@ -137,11 +138,11 @@ def _line_chart(goals: List[GoalArea]) -> None:
         rate = (successes / total) * 100 if total else 0
         rates.append(rate)
 
-    x = list(range(30))
+    x = list(range(DEFAULT_TIMEFRAME))
     plt.clear_data()
     plt.clear_figure()
     plt.plot(x, rates)
-    plt.title("Success Rate (Last 30 Days)")
+    plt.title(f"Success Rate (Last {DEFAULT_TIMEFRAME} Days)")
     plt.ylim(0, 100)
     plt.yticks([0, 25, 50, 75, 100])
     plt.show()

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -18,6 +18,7 @@ from rich.table import Table
 
 from loopbloom.cli import with_goals
 from loopbloom.cli.utils import goal_not_found
+from loopbloom.constants import WINDOW_DEFAULT
 from loopbloom.core import config as cfg
 from loopbloom.core.models import GoalArea
 from loopbloom.core.progression import should_advance
@@ -25,8 +26,6 @@ from loopbloom.core.progression import should_advance
 console = Console()
 
 logger = logging.getLogger(__name__)
-
-WINDOW_DEFAULT = 14  # days
 
 
 @click.command(

--- a/loopbloom/constants.py
+++ b/loopbloom/constants.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from loopbloom.core.config import APP_DIR
+
+# Base package directory
+PACKAGE_DIR = Path(__file__).resolve().parent
+
+# Bundled data directory and resources
+DATA_DIR = PACKAGE_DIR / "data"
+COPING_DIR = DATA_DIR / "coping"
+TALKS_PATH = DATA_DIR / "default_talks.json"
+
+# User data files
+REVIEW_PATH = APP_DIR / "reviews.json"
+REVIEW_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+JOURNAL_PATH = APP_DIR / "journal.json"
+JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+JSON_STORE_PATH = Path(os.getenv("LOOPBLOOM_DATA_PATH", APP_DIR / "data.json"))
+JSON_STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+SQLITE_STORE_PATH = Path(os.getenv("LOOPBLOOM_SQLITE_PATH", APP_DIR / "data.db"))
+SQLITE_STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+# Progression and reporting defaults
+WINDOW_DEFAULT = 14
+THRESHOLD_DEFAULT = 0.80
+DEFAULT_TIMEFRAME = 30

--- a/loopbloom/core/coping.py
+++ b/loopbloom/core/coping.py
@@ -12,8 +12,7 @@ from typing import Any, Dict, List
 
 import yaml
 
-# Directory containing YAML coping plans bundled with the package.
-COPING_DIR = Path(__file__).resolve().parent.parent / "data" / "coping"
+from loopbloom.constants import COPING_DIR
 
 
 class CopingPlanError(RuntimeError):

--- a/loopbloom/core/journal.py
+++ b/loopbloom/core/journal.py
@@ -7,10 +7,7 @@ from typing import List
 from pydantic import BaseModel, Field
 from pydantic.json import pydantic_encoder
 
-from loopbloom.core.config import APP_DIR
-
-JOURNAL_PATH = APP_DIR / "journal.json"
-JOURNAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+from loopbloom.constants import JOURNAL_PATH
 
 
 class JournalEntry(BaseModel):

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -9,13 +9,10 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import List
 
+from loopbloom.constants import THRESHOLD_DEFAULT, WINDOW_DEFAULT
 from loopbloom.core import config as cfg
 from loopbloom.core.config import ProgressionStrategy
 from loopbloom.core.models import Checkin, MicroGoal
-
-# Default history window and success rate threshold for progression logic.
-WINDOW_DEFAULT = 14  # days to consider
-THRESHOLD_DEFAULT = 0.80  # 80 % success required
 
 
 def _recent_checkins(checkins: List[Checkin], window: int) -> List[Checkin]:

--- a/loopbloom/core/review.py
+++ b/loopbloom/core/review.py
@@ -7,10 +7,7 @@ from typing import List
 from pydantic import BaseModel, Field
 from pydantic.json import pydantic_encoder
 
-from loopbloom.core.config import APP_DIR
-
-REVIEW_PATH = APP_DIR / "reviews.json"
-REVIEW_PATH.parent.mkdir(parents=True, exist_ok=True)
+from loopbloom.constants import REVIEW_PATH
 
 
 class ReviewEntry(BaseModel):

--- a/loopbloom/core/talks.py
+++ b/loopbloom/core/talks.py
@@ -8,13 +8,9 @@ from __future__ import annotations
 
 import json
 import random
-from pathlib import Path
 from typing import Dict, List
 
-# Directory containing bundled data files such as the default pep talks.
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
-# JSON file with two lists of pep-talk snippets keyed by mood (success/skip).
-TALKS_PATH = DATA_DIR / "default_talks.json"
+from loopbloom.constants import TALKS_PATH
 
 
 class TalkPool:

--- a/loopbloom/storage/json_store.py
+++ b/loopbloom/storage/json_store.py
@@ -8,24 +8,19 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import ContextManager, List
 
 from pydantic.json import pydantic_encoder
 
-from loopbloom.core.config import APP_DIR
+from loopbloom.constants import JSON_STORE_PATH
 from loopbloom.core.models import GoalArea
 from loopbloom.storage.base import Storage, StorageError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_PATH = Path(os.getenv("LOOPBLOOM_DATA_PATH", APP_DIR / "data.json"))
-# Ensure the data directory exists before any read/write operations.
-# Users may override this path via the ``LOOPBLOOM_DATA_PATH`` environment
-# variable for ad-hoc experiments or testing.
-DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+DEFAULT_PATH = JSON_STORE_PATH
 
 
 class JSONStore(Storage):

--- a/loopbloom/storage/sqlite_store.py
+++ b/loopbloom/storage/sqlite_store.py
@@ -4,7 +4,6 @@ SQLAlchemy Core for lightweight database access."""
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import List
 
@@ -22,14 +21,11 @@ from sqlalchemy import (
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
-from loopbloom.core.config import APP_DIR
+from loopbloom.constants import SQLITE_STORE_PATH
 from loopbloom.core.models import GoalArea
 from loopbloom.storage.base import Storage, StorageError
 
-DEFAULT_PATH = Path(os.getenv("LOOPBLOOM_SQLITE_PATH", APP_DIR / "data.db"))
-# Ensure parent directory exists for the database file.
-# ``LOOPBLOOM_SQLITE_PATH`` can relocate the DB for testing or advanced usage.
-DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+DEFAULT_PATH = SQLITE_STORE_PATH
 
 metadata = MetaData()
 

--- a/tests/integration/test_cope_new.py
+++ b/tests/integration/test_cope_new.py
@@ -12,8 +12,10 @@ def test_cope_new(tmp_path, monkeypatch):
     coping_dir = tmp_path / "coping"
     coping_dir.mkdir()
 
+    import loopbloom.constants as const_mod
     import loopbloom.core.coping as cp_mod
 
+    monkeypatch.setattr(const_mod, "COPING_DIR", coping_dir)
     monkeypatch.setattr(cp_mod, "COPING_DIR", coping_dir)
     import loopbloom.cli as cli_mod
     import loopbloom.cli.cope as cope_mod

--- a/tests/unit/test_journal_cli.py
+++ b/tests/unit/test_journal_cli.py
@@ -10,10 +10,12 @@ from click.testing import CliRunner
 def _reload_cli(tmp_path: Path, monkeypatch) -> any:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     import loopbloom.__main__ as main
+    import loopbloom.constants as const_mod
     import loopbloom.core.config as cfg_mod
     import loopbloom.core.journal as journal_mod
 
     importlib.reload(cfg_mod)
+    importlib.reload(const_mod)
     importlib.reload(journal_mod)
     importlib.reload(main)
     return main.cli

--- a/tests/unit/test_review_cli.py
+++ b/tests/unit/test_review_cli.py
@@ -10,10 +10,12 @@ from click.testing import CliRunner
 def _reload_cli(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     import loopbloom.__main__ as main
+    import loopbloom.constants as const_mod
     import loopbloom.core.config as cfg_mod
     import loopbloom.core.review as review_mod
 
     importlib.reload(cfg_mod)
+    importlib.reload(const_mod)
     importlib.reload(review_mod)
     importlib.reload(main)
     return main.cli


### PR DESCRIPTION
## Summary
- move default settings and file paths into `constants.py`
- update CLI and core modules to use centralized constants
- adjust tests to reload constants when reloading config

## Testing
- `poetry run pytest tests/integration/test_cope_new.py tests/unit/test_journal_cli.py tests/unit/test_review_cli.py -q`
- `./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68687c0ef6448322ab6925145d4d7463