### PR TITLE
Add interactive micro-goal selection for checkin

### DIFF
--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -11,7 +11,7 @@ import click
 from rich import print
 
 from loopbloom.cli import with_goals
-from loopbloom.cli.interactive import choose_from, interactive_select
+from loopbloom.cli.interactive import interactive_select
 from loopbloom.cli.utils import goal_not_found
 from loopbloom.core.models import Checkin, GoalArea, MicroGoal, Status
 from loopbloom.core.talks import TalkPool
@@ -52,7 +52,7 @@ def checkin(
     if fail:
         success = False
 
-    mg = None
+    mg: MicroGoal | None = None
     goal: GoalArea | None = None
 
     # Interactive selection when no goal specified
@@ -106,6 +106,8 @@ def checkin(
             logger.error("No active micro-goal in goal %s", goal.name)
             click.echo("[red]No active micro-goal found for this goal.")
             return
+
+    assert mg is not None
     # Inform the user which micro-habit is being checked in
     logger.info("Checking in for %s", mg.name)
     click.echo(f"Checking in for: [bold]{mg.name}[/bold]")

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -11,9 +11,9 @@ import click
 from rich import print
 
 from loopbloom.cli import with_goals
-from loopbloom.cli.interactive import choose_from
+from loopbloom.cli.interactive import choose_from, interactive_select
 from loopbloom.cli.utils import goal_not_found
-from loopbloom.core.models import Checkin, GoalArea
+from loopbloom.core.models import Checkin, GoalArea, MicroGoal, Status
 from loopbloom.core.talks import TalkPool
 from loopbloom.services.progression import ProgressionService
 
@@ -51,35 +51,61 @@ def checkin(
     # alias for ``--skip`` and overrides ``success`` when provided.
     if fail:
         success = False
-    # If the user did not specify which goal to log, prompt with a list.
+
+    mg = None
+    goal: GoalArea | None = None
+
+    # Interactive selection when no goal specified
     if goal_name is None:
-        names = [g.name for g in goals]
-        if not names:
+        if not goals:
             logger.error("No goals available for check-in")
             click.echo("[red]No goals – use `loopbloom goal add`.")
             return
+
         click.echo("Which goal do you want to check in for?")
-        logger.info("Prompting for goal selection")
-        goal_name = choose_from(names, "Enter number")
-        if goal_name is None:
+
+        active: list[tuple[str, tuple[GoalArea, MicroGoal]]] = []
+        for g in goals:
+            for ph in g.phases:
+                for m in ph.micro_goals:
+                    if m.status is Status.active:
+                        active.append((f"{g.name} -> {ph.name} -> {m.name}", (g, m)))
+            for m in g.micro_goals:
+                if m.status is Status.active:
+                    active.append((f"{g.name} -> {m.name}", (g, m)))
+
+        if not active:
+            logger.info("No active micro-goals for interactive check-in")
+            click.echo("No active micro-goals to check in for.")
             return
 
-    # Locate the goal by name (case-insensitive) from the loaded list.
-    goal = next(
-        (g for g in goals if g.name.lower() == goal_name.lower()),
-        None,
-    )
-    if not goal:
-        logger.error("Goal not found: %s", goal_name)
-        goal_not_found(goal_name, [g.name for g in goals])
-        return
-    # Find the active micro-goal
-    mg = goal.get_active_micro_goal()
+        selection = interactive_select(
+            "Select a micro-goal to check in for",
+            {label: pair for label, pair in active},
+        )
+        if selection is None:
+            return
 
-    if mg is None:
-        logger.error("No active micro-goal in goal %s", goal.name)
-        click.echo("[red]No active micro-goal found for this goal.")
-        return
+        goal, mg = selection
+        goal_name = goal.name
+
+    # Locate the goal by name if it wasn't selected interactively.
+    if goal is None:
+        goal = next(
+            (g for g in goals if g.name.lower() == goal_name.lower()),
+            None,
+        )
+        if not goal:
+            logger.error("Goal not found: %s", goal_name)
+            goal_not_found(goal_name, [g.name for g in goals])
+            return
+        # Find the active micro-goal in the chosen goal
+        mg = goal.get_active_micro_goal()
+
+        if mg is None:
+            logger.error("No active micro-goal in goal %s", goal.name)
+            click.echo("[red]No active micro-goal found for this goal.")
+            return
     # Inform the user which micro-habit is being checked in
     logger.info("Checking in for %s", mg.name)
     click.echo(f"Checking in for: [bold]{mg.name}[/bold]")

--- a/loopbloom/cli/interactive.py
+++ b/loopbloom/cli/interactive.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional, TypeVar
+from typing import Iterable, List, Mapping, Optional, TypeVar
 
 import click
 
@@ -21,3 +21,14 @@ def choose_from(options: Iterable[T], prompt: str) -> Optional[T]:
     # Use ``click.IntRange`` to validate the choice automatically.
     idx: int = click.prompt(prompt, type=click.IntRange(1, len(items)))
     return items[idx - 1]
+
+
+def interactive_select(prompt: str, options: Mapping[str, T]) -> Optional[T]:
+    """Present ``options`` as a numbered menu and return the chosen item."""
+    if not options:
+        return None
+    labels = list(options.keys())
+    for i, label in enumerate(labels, 1):
+        click.echo(f"{i}. {label}")
+    idx: int = click.prompt(prompt, type=click.IntRange(1, len(labels)))
+    return options[labels[idx - 1]]

--- a/tests/unit/test_additional_coverage.py
+++ b/tests/unit/test_additional_coverage.py
@@ -458,7 +458,7 @@ def test_checkin_cancel(
 
     cli = _reload_cli(tmp_path, monkeypatch)
     JSONStore(path=tmp_path / "data.json").save([GoalArea(name="G")])
-    monkeypatch.setattr(checkin_mod, "choose_from", lambda *_, **__: None)
+    monkeypatch.setattr(checkin_mod, "interactive_select", lambda *_, **__: None)
     runner = CliRunner()
     env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
     res = runner.invoke(cli, ["checkin"], env=env)


### PR DESCRIPTION
## Summary
- add `interactive_select` helper for mapping-based menus
- enable interactive micro-goal selection in `checkin` command

## Testing
- `./scripts/pre-commit`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6868840190108322a6f3e613284716e7