### PR TITLE
Improve reasoning in inline comments

### DIFF
--- a/loopbloom/cli/backup.py
+++ b/loopbloom/cli/backup.py
@@ -36,7 +36,8 @@ def backup() -> None:
     """Copy the active data file into :data:`BACKUP_DIR`."""
     config = cfg.load()
     storage = config.get("storage", "json")
-    # User may override the default data file location in the config.
+    # Allow the user to relocate the data file via configuration. This keeps
+    # backups in sync with whatever path they have chosen.
     cfg_path = str(config.get("data_path") or "")
 
     if storage == "sqlite":

--- a/loopbloom/cli/config.py
+++ b/loopbloom/cli/config.py
@@ -41,10 +41,11 @@ def _get(key: str) -> None:
     Args:
         key: Dot-separated key, e.g. ``advance.window``.
     """
-    # ``key`` may refer to nested values like ``advance.window`` which maps
-    # to ``{"advance": {"window": ...}}`` in the TOML file.
+    # ``key`` may contain dots to access nested sections, e.g. ``advance.window``
+    # refers to ``{"advance": {"window": ...}}`` inside the TOML file.
     val: Any = cfg.load()
-    # Walk the nested dictionaries using ``.`` as a separator.
+    # Traverse the nested dictionaries using ``.`` so arbitrarily deep keys can
+    # be read.
     for part in key.split("."):
         val = val.get(part) if isinstance(val, dict) else None
     if val is None:
@@ -69,7 +70,8 @@ def _set(key: str, value: str) -> None:
     conf = cfg.load()
     parts = key.split(".")
     d = conf
-    # Walk down the hierarchy, creating intermediate dictionaries as needed
+    # Create parent sections on the fly so ``config set a.b.c`` works even when
+    # ``a`` or ``b`` don't exist yet.
     for p in parts[:-1]:
         d = d.setdefault(p, {})
     # Convert the string to int/float/bool when possible so numbers are not

--- a/loopbloom/cli/cope.py
+++ b/loopbloom/cli/cope.py
@@ -24,7 +24,8 @@ def cope() -> None:
 
 @cope.command(name="list", help="Show available coping plans.")
 def _list() -> None:
-    # Show all YAML plans bundled or created by the user.
+    # Display every available plan so the user knows what can be executed or
+    # edited.
     plans = PlanRepository.list_plans()
     logger.info("Listing coping plans")
     for p in plans:
@@ -34,7 +35,8 @@ def _list() -> None:
 @cope.command(name="run", help="Run a coping plan by ID.")
 @click.argument("plan_id")
 def _run(plan_id: str) -> None:
-    # Load the requested plan from disk.
+    # Fetch the plan fresh from disk to ensure we run the most up-to-date
+    # version.
     plan = PlanRepository.get(plan_id)
     if not plan:
         logger.error("Plan not found: %s", plan_id)
@@ -58,7 +60,8 @@ def _new() -> None:
     msg = "Add steps. Type 'p' for prompt, 'm' for message, 'q' to finish."
     click.echo(msg)
     steps = []
-    # Steps are collected interactively until the user chooses to quit.
+    # Keep prompting for step definitions until the user indicates they're
+    # finished, allowing an arbitrary number of steps to be added.
     while True:
         kind = click.prompt("Step type", default="q").lower().strip()
         if kind.startswith("q"):

--- a/loopbloom/cli/export.py
+++ b/loopbloom/cli/export.py
@@ -37,7 +37,8 @@ def export(store: Storage, fmt: str, out_path: str) -> None:
 
     Usage: ``loopbloom export --fmt csv --out progress.csv``
     """
-    # Load all goals from the configured storage backend.
+    # Use whichever storage backend the user configured so exports always match
+    # their real data.
     logger.info("Exporting data to %s as %s", out_path, fmt)
     goals = store.load()
 
@@ -48,8 +49,8 @@ def export(store: Storage, fmt: str, out_path: str) -> None:
         click.echo(f"[green]Exported JSON → {out_path}")
         return
 
-    # CSV export produces a flat table where each row represents a single
-    # check-in. The first row is the header matching the column order below.
+    # CSV output is a flat table – one row per check-in – to make importing the
+    # data into spreadsheets straightforward. The first row acts as the header.
     rows: List[List[str]] = [
         [
             "date",
@@ -64,7 +65,8 @@ def export(store: Storage, fmt: str, out_path: str) -> None:
         for ph in g.phases:
             for m in ph.micro_goals:
                 for ci in m.checkins:
-                    # Flatten nested objects into a simple row per check-in.
+                    # Collapse the hierarchical objects into a row so external
+                    # tools don't need to understand our data model.
                     rows.append(
                         [
                             str(ci.date),

--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -59,8 +59,8 @@ def _calendar_heatmap(goals: List[GoalArea]) -> None:
     """Print an ASCII calendar heatmap of the current month."""
     today = date.today()
     cal = Calendar()
-    # Build map of day -> (successes, total)
-    # Map day -> (number of successes, total check-ins)
+    # Track both successes and total check-ins per day so the heatmap can
+    # shade each cell based on performance rather than mere activity.
     stats: dict[int, tuple[int, int]] = {}
     for m in _gather_all_micro(goals):
         for ci in m.checkins:
@@ -98,7 +98,8 @@ def _success_bars(goals: List[GoalArea]) -> None:
     for g in goals:
         successes = 0
         total = 0
-        # Aggregate all check-ins for this goal across phases.
+        # Combine check-ins from every micro-habit so the bar reflects the
+        # goal's overall success rate.
         for m in _gather_all_micro([g]):
             for ci in m.checkins:
                 total += 1

--- a/loopbloom/cli/tree.py
+++ b/loopbloom/cli/tree.py
@@ -20,17 +20,18 @@ console = Console()
 @with_goals
 def tree(goals: List[GoalArea]) -> None:
     """Display all goals, phases, and micro-habits in a tree view."""
-    # Root node representing the entire goal collection. The tree emoji makes
-    # it easy to spot this view in terminal scrollback.
+    # Start with a single root node. The tree emoji helps users quickly locate
+    # this view in their terminal history.
     root = Tree("\U0001f333 LoopBloom Goals")
     for g in goals:
         g_branch = root.add(g.name)
-        # List micro-habits grouped under each phase
+        # Show micro-habits grouped by phase to mirror the goal hierarchy.
         for ph in g.phases:
             p_branch = g_branch.add(f"[dim]Phase:[/] {ph.name}")
             for m in ph.micro_goals:
                 p_branch.add(m.name)
-        # Micro-habits attached directly to the goal
+        # Also include any micro-habits that aren't part of a phase so nothing
+        # is missed.
         for m in g.micro_goals:
             g_branch.add(m.name)
     console.print(root)

--- a/loopbloom/core/models.py
+++ b/loopbloom/core/models.py
@@ -25,25 +25,30 @@ class Status(str, Enum):
 class Checkin(BaseModel):
     """A single daily micro-goal check-in."""
 
-    # Date when the check-in occurred (defaults to today).
+    # Store the day separately from the timestamp so daily statistics remain
+    # consistent regardless of timezone.
     date: dt_date = Field(default_factory=dt_date.today)
     success: bool
     note: str | None = None
-    # Optional pep-talk chosen at check-in time.
+    # Persist the pep talk shown to the user so past encouragement can be
+    # displayed alongside the check-in history.
     self_talk_generated: str | None = None
 
 
 class MicroGoal(BaseModel):
     """A very small behavioural target the user wants to track."""
 
-    # Unique identifier for referencing this micro-habit.
+    # Use a UUID rather than the name so references remain valid even if the
+    # micro-habit gets renamed later.
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str
     status: Status = Status.active
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    # History of successes/failures for this micro-habit.
+    # Chronological log of successes and skips used when calculating streaks
+    # and advancement eligibility.
     checkins: list[Checkin] = Field(default_factory=list)
-    # Optional progression overrides for this specific micro-habit.
+    # Allow this micro-habit to override the global advancement rules with its
+    # own window and threshold values.
     advancement_window: int | None = None
     advancement_threshold: float | None = None
 

--- a/loopbloom/services/notifier.py
+++ b/loopbloom/services/notifier.py
@@ -39,8 +39,9 @@ def send(
     Returns:
         None
     """
-    # ``mode`` controls the delivery mechanism. ``desktop`` uses plyer,
-    # ``terminal`` prints to stdout, and ``none`` disables notifications.
+    # ``mode`` determines how we deliver the notification. We honour the user's
+    # preference but fall back gracefully when dependencies like ``plyer`` are
+    # unavailable.
     config = cfg.load()
     pause_until = config.get("pause_until")
     if pause_until:


### PR DESCRIPTION
## Summary
- clarify reasoning for configuration operations
- explain interactive command prompts
- document data export and reporting calculations
- refine logic comments in CLI utilities
- elaborate on models and notification logic

## Testing
- `poetry install`
- `./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6868bcb4dae883228fca5d023c7d1a9d