### PR TITLE
Add tests for invalid pause durations

### DIFF
--- a/loopbloom/cli/pause.py
+++ b/loopbloom/cli/pause.py
@@ -31,8 +31,10 @@ def pause(goal_name: str | None, duration: str) -> None:
     """Pause notifications for ``duration`` days or weeks."""
     delta = _parse_duration(duration)
     if not delta:
-        click.echo("[red]Invalid duration. Use Nd or Nw e.g. 3d, 1w")
-        return
+        raise click.BadParameter(
+            "Invalid duration format. Use Nd or Nw e.g. 3d, 1w",
+            param_hint="--for",
+        )
     until = (date.today() + delta).isoformat()
     conf = cfg.load()
     if goal_name:

--- a/tests/integration/test_pause_cmd.py
+++ b/tests/integration/test_pause_cmd.py
@@ -2,6 +2,55 @@ import importlib
 
 from click.testing import CliRunner
 
+import loopbloom.core.config as cfg_mod
+
+
+class TestPauseCommand:
+    def test_pause_with_invalid_duration_format(self, tmp_path, monkeypatch):
+        """Invalid duration strings should not alter the config."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        importlib.reload(cfg_mod)
+        import loopbloom.__main__ as main
+
+        importlib.reload(main)
+
+        runner = CliRunner()
+        env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+        runner.invoke(main.cli, ["goal", "add", "Test Goal"], env=env)
+        result = runner.invoke(main.cli, ["pause", "--for", "2months"], env=env)
+
+        assert result.exit_code != 0
+        assert "Invalid duration format" in result.output
+
+        conf = cfg_mod.load()
+        assert conf.get("pause_until", "") == ""
+        assert conf.get("goal_pauses", {}) == {}
+
+    def test_pause_goal_with_invalid_duration(self, tmp_path, monkeypatch):
+        """Pausing a specific goal with an invalid duration fails gracefully."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        importlib.reload(cfg_mod)
+        import loopbloom.__main__ as main
+
+        importlib.reload(main)
+
+        runner = CliRunner()
+        env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+        runner.invoke(main.cli, ["goal", "add", "Another Goal"], env=env)
+        result = runner.invoke(
+            main.cli,
+            ["pause", "--goal", "Another Goal", "--for", "1year"],
+            env=env,
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid duration format" in result.output
+
+        conf = cfg_mod.load()
+        assert "Another Goal" not in conf.get("goal_pauses", {})
+
 
 def test_pause_global(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- raise `BadParameter` when pause duration format is invalid
- add integration tests covering invalid pause durations

## Testing
- `poetry install`
- `./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6869d61da7d48322915e69d35152f33f