### PR TITLE
Add debug mode with time override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,13 @@ For convenience, a helper script combines linting, type checks and tests. Run it
 
 It fails if any step does not pass, mirroring the checks that run in CI.
 
+## Debugging
+
+Use the global `--debug` flag for verbose output when running any CLI command.
+You can also run commands with `--dry-run` to avoid writing changes. Set the
+environment variable `LOOPBLOOM_DEBUG_DATE` to override the current date for
+testing time-sensitive logic.
+
 ## Submitting Pull Requests
 
 1. Fork the repository on GitHub and create a feature branch.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ loopbloom export --fmt csv --out ~/Desktop/loopbloom_progress.csv
 
 *Thin CLI → Service → Core → Storage* layered architecture; see [USER_GUIDE.md](USER_GUIDE.md) for full docs.
 
+### Debugging
+
+Enable debug mode on any command with `--debug` to see verbose logging and
+extra diagnostics. Use `--dry-run` to preview changes without saving them.
+The application date can be overridden for testing by setting the
+`LOOPBLOOM_DEBUG_DATE` environment variable (YYYY-MM-DD). To dump the raw
+goal state run `loopbloom debug-state`.
+
 <a id="testing"></a>
 
 ## 14  Testing & CI

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -65,6 +65,10 @@ def checkin(
 
     mg: MicroGoal | None = None
     goal: GoalArea | None = None
+    today = get_current_datetime().date()
+    logger.debug("Check-in date: %s", today)
+    if ctx.obj.debug:
+        click.echo(f"Check-in recorded for date: {today}")
 
     # If the user omitted a goal we ask interactively to ensure the check-in is
     # attributed to the correct micro-habit.
@@ -130,13 +134,10 @@ def checkin(
     talk = TalkPool.random("success" if success else "skip")
     if success and "\u2713" not in talk:
         talk = "\u2713 " + talk
-    today = get_current_datetime().date()
     ci = Checkin(
         date=today, success=success, note=note or None, self_talk_generated=talk
     )
     logger.debug("Check-in recorded for date: %s", today)
-    if ctx.obj.debug:
-        click.echo(f"Check-in recorded for date: {today}")
     mg.checkins.append(ci)
 
     # Output pep-talk so the user gets immediate encouragement.

--- a/loopbloom/cli/checkin.py
+++ b/loopbloom/cli/checkin.py
@@ -15,6 +15,7 @@ from loopbloom.cli.interactive import interactive_select
 from loopbloom.cli.utils import goal_not_found
 from loopbloom.core.models import Checkin, GoalArea, MicroGoal, Status
 from loopbloom.core.talks import TalkPool
+from loopbloom.services.datetime import get_current_datetime
 from loopbloom.services.progression import ProgressionService
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,11 @@ def checkin(
     # ``success`` picks the pep-talk mood. ``fail`` is merely an alias for
     # ``--skip`` and flips ``success`` when present. The optional ``note`` is
     # stored verbatim with the check-in.
+    logger.debug("Starting check-in for goal_name=%s", goal_name)
+    ctx = click.get_current_context()
+    logger.debug("Dry run mode is %s", "ON" if ctx.obj.dry_run else "OFF")
+    if ctx.obj.debug:
+        click.echo(f"Dry run: {ctx.obj.dry_run}")
     if fail:
         success = False
 
@@ -124,7 +130,13 @@ def checkin(
     talk = TalkPool.random("success" if success else "skip")
     if success and "\u2713" not in talk:
         talk = "\u2713 " + talk
-    ci = Checkin(success=success, note=note or None, self_talk_generated=talk)
+    today = get_current_datetime().date()
+    ci = Checkin(
+        date=today, success=success, note=note or None, self_talk_generated=talk
+    )
+    logger.debug("Check-in recorded for date: %s", today)
+    if ctx.obj.debug:
+        click.echo(f"Check-in recorded for date: {today}")
     mg.checkins.append(ci)
 
     # Output pep-talk so the user gets immediate encouragement.

--- a/loopbloom/cli/debug.py
+++ b/loopbloom/cli/debug.py
@@ -1,0 +1,36 @@
+import json
+import os
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from loopbloom.core import config as cfg
+from loopbloom.storage.json_store import DEFAULT_PATH as JSON_DEFAULT_PATH
+from loopbloom.storage.sqlite_store import DEFAULT_PATH as SQLITE_DEFAULT_PATH
+
+console = Console()
+
+
+@click.command(name="debug-state", help="Dump raw JSON goal state.")
+def debug_state() -> None:
+    """Print the contents of the current goals file."""
+    config = cfg.load()
+    storage = config.get("storage", "json")
+    cfg_path = str(config.get("data_path") or "")
+    if storage == "sqlite":
+        path = (
+            os.getenv("LOOPBLOOM_SQLITE_PATH") or cfg_path or str(SQLITE_DEFAULT_PATH)
+        )
+    else:
+        path = os.getenv("LOOPBLOOM_DATA_PATH") or cfg_path or str(JSON_DEFAULT_PATH)
+    data_file = Path(path)
+    if not data_file.exists():
+        console.print("[yellow]Goals file not found.[/yellow]")
+        return
+    with open(data_file, "r") as f:
+        state = json.load(f)
+    console.print_json(json.dumps(state))
+
+
+debug_state_cmd = debug_state

--- a/loopbloom/cli/export.py
+++ b/loopbloom/cli/export.py
@@ -12,8 +12,6 @@ from typing import List
 
 import click
 
-from loopbloom.storage.base import Storage
-
 logger = logging.getLogger(__name__)
 
 
@@ -31,8 +29,8 @@ logger = logging.getLogger(__name__)
     required=True,
     help="File to write exported data to.",
 )
-@click.pass_obj
-def export(store: Storage, fmt: str, out_path: str) -> None:
+@click.pass_context
+def export(ctx: click.Context, fmt: str, out_path: str) -> None:
     """Write all goal history to OUT_PATH in format FMT.
 
     Usage: ``loopbloom export --fmt csv --out progress.csv``
@@ -40,6 +38,7 @@ def export(store: Storage, fmt: str, out_path: str) -> None:
     # Use whichever storage backend the user configured so exports always match
     # their real data.
     logger.info("Exporting data to %s as %s", out_path, fmt)
+    store = ctx.obj.store
     goals = store.load()
 
     if fmt == "json":

--- a/loopbloom/cli/goal.py
+++ b/loopbloom/cli/goal.py
@@ -33,6 +33,11 @@ def goal() -> None:
 @with_goals
 def goal_add(name: str, notes: str, goals: List[GoalArea]) -> None:
     """Add a new goal area."""
+    logger.debug("Received call to 'goal add' with name='%s'", name)
+    from click import get_current_context
+
+    ctx = get_current_context()
+    logger.debug("Dry run mode is %s", "ON" if ctx.obj.dry_run else "OFF")
     if find_goal(goals, name):
         logger.error("Goal already exists: %s", name)
         click.echo("[yellow]Goal already exists.")

--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -261,7 +261,8 @@ def micro_add(
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
         return  # pragma: no cover
 
-    store = click.get_current_context().obj
+    ctx = click.get_current_context()
+    store = ctx.obj.store
 
     target_phase = _get_or_select_phase(store, goal_name, phase_name)
     if phase_name and target_phase is None:
@@ -329,7 +330,7 @@ def micro_rm(
         return
 
     result = _get_or_select_micro_goal(
-        click.get_current_context().obj,
+        click.get_current_context().obj.store,
         goal_name,
         phase_name,
         name,
@@ -360,8 +361,8 @@ def micro_rm(
         return
 
     target_list.remove(mg_actual)
-    store = click.get_current_context().obj
-    store.save_goal_area(g)
+    ctx = click.get_current_context()
+    ctx.obj.store.save_goal_area(g)
     logger.info("Deleted micro-habit %s", mg.name)
     click.echo(f"[green]Deleted micro-habit:[/] {mg.name}")
 

--- a/loopbloom/cli/pause.py
+++ b/loopbloom/cli/pause.py
@@ -1,8 +1,9 @@
-from datetime import date, timedelta
+from datetime import timedelta
 
 import click
 
 from loopbloom.core import config as cfg
+from loopbloom.services.datetime import get_current_datetime
 
 _DEF_HELP = "Pause notifications globally or for a specific goal."
 
@@ -35,7 +36,7 @@ def pause(goal_name: str | None, duration: str) -> None:
             "Invalid duration format. Use Nd or Nw e.g. 3d, 1w",
             param_hint="--for",
         )
-    until = (date.today() + delta).isoformat()
+    until = (get_current_datetime().date() + delta).isoformat()
     conf = cfg.load()
     if goal_name:
         pauses = conf.get("goal_pauses", {})

--- a/loopbloom/cli/report.py
+++ b/loopbloom/cli/report.py
@@ -7,7 +7,7 @@ heatmap, bar chart or simple line graph to visualise progress.
 from __future__ import annotations
 
 from calendar import Calendar, month_name
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import Iterable, Iterator, List
 
 import click
@@ -18,6 +18,7 @@ from rich.table import Table
 from loopbloom.cli import with_goals
 from loopbloom.constants import DEFAULT_TIMEFRAME
 from loopbloom.core.models import GoalArea, MicroGoal
+from loopbloom.services.datetime import get_current_datetime
 
 console = Console()
 
@@ -57,7 +58,7 @@ def _gather_all_micro(goals: Iterable[GoalArea]) -> Iterator[MicroGoal]:
 
 def _calendar_heatmap(goals: List[GoalArea]) -> None:
     """Print an ASCII calendar heatmap of the current month."""
-    today = date.today()
+    today = get_current_datetime().date()
     cal = Calendar()
     # Track both successes and total check-ins per day so the heatmap can
     # shade each cell based on performance rather than mere activity.
@@ -122,7 +123,7 @@ def _line_chart(goals: List[GoalArea]) -> None:
     # the library isn't installed.
     import plotext as plt
 
-    today = date.today()
+    today = get_current_datetime().date()
     start = today - timedelta(days=DEFAULT_TIMEFRAME - 1)
 
     rates: list[float] = []

--- a/loopbloom/cli/summary.py
+++ b/loopbloom/cli/summary.py
@@ -8,7 +8,7 @@ checks whether it should be advanced.
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import List
 
 import click
@@ -22,6 +22,7 @@ from loopbloom.constants import WINDOW_DEFAULT
 from loopbloom.core import config as cfg
 from loopbloom.core.models import GoalArea
 from loopbloom.core.progression import should_advance
+from loopbloom.services.datetime import get_current_datetime
 
 console = Console()
 
@@ -56,7 +57,7 @@ def _overview(goals: List[GoalArea]) -> None:
     table.add_column("Goal")
     table.add_column("Successes")
     table.add_column("Next Action")
-    today = date.today()
+    today = get_current_datetime().date()
 
     for g in goals:
         successes = 0

--- a/loopbloom/cli/utils.py
+++ b/loopbloom/cli/utils.py
@@ -76,7 +76,8 @@ def get_goal_from_name(name: str) -> Optional[GoalArea]:
     Returns:
         The :class:`GoalArea` when found, otherwise ``None``.
     """
-    store = click.get_current_context().obj
+    ctx = click.get_current_context()
+    store = ctx.obj.store
     goals = store.load()
     return next((g for g in goals if g.name.lower() == name.lower()), None)
 
@@ -87,5 +88,5 @@ def save_goal(goal: GoalArea) -> None:
     Args:
         goal: Goal to save.
     """
-    store = click.get_current_context().obj
-    store.save_goal_area(goal)
+    ctx = click.get_current_context()
+    ctx.obj.store.save_goal_area(goal)

--- a/loopbloom/core/models.py
+++ b/loopbloom/core/models.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field, field_validator
 
+from loopbloom.services.datetime import get_current_datetime
+
 
 class Status(str, Enum):
     """Lifecycle stages for a :class:`MicroGoal`."""
@@ -27,7 +29,7 @@ class Checkin(BaseModel):
 
     # Store the day separately from the timestamp so daily statistics remain
     # consistent regardless of timezone.
-    date: dt_date = Field(default_factory=dt_date.today)
+    date: dt_date = Field(default_factory=lambda: get_current_datetime().date())
     success: bool
     note: str | None = None
     # Persist the pep talk shown to the user so past encouragement can be

--- a/loopbloom/core/progression.py
+++ b/loopbloom/core/progression.py
@@ -6,13 +6,14 @@ If an active micro-habit hits ≥ `threshold` success ratio within the last
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import List
 
 from loopbloom.constants import THRESHOLD_DEFAULT, WINDOW_DEFAULT
 from loopbloom.core import config as cfg
 from loopbloom.core.config import ProgressionStrategy
 from loopbloom.core.models import Checkin, MicroGoal
+from loopbloom.services.datetime import get_current_datetime
 
 
 def _recent_checkins(checkins: List[Checkin], window: int) -> List[Checkin]:
@@ -27,7 +28,7 @@ def _recent_checkins(checkins: List[Checkin], window: int) -> List[Checkin]:
         specified window.
     """
     # ``window`` is inclusive of today, so a 7-day window looks back 6 days.
-    cutoff = date.today() - timedelta(days=window - 1)
+    cutoff = get_current_datetime().date() - timedelta(days=window - 1)
     # Return only the check-ins that fall within the calculated window.
     return [ci for ci in checkins if ci.date >= cutoff]
 

--- a/loopbloom/services/datetime.py
+++ b/loopbloom/services/datetime.py
@@ -1,0 +1,13 @@
+import os
+from datetime import datetime
+
+
+def get_current_datetime() -> datetime:
+    """Return the current datetime allowing override via env var."""
+    debug_date_str = os.environ.get("LOOPBLOOM_DEBUG_DATE")
+    if debug_date_str:
+        try:
+            return datetime.strptime(debug_date_str, "%Y-%m-%d")
+        except ValueError:
+            return datetime.now()
+    return datetime.now()

--- a/loopbloom/services/notifier.py
+++ b/loopbloom/services/notifier.py
@@ -11,6 +11,7 @@ from datetime import date
 from typing import Literal
 
 from loopbloom.core import config as cfg
+from loopbloom.services.datetime import get_current_datetime
 
 try:
     from plyer import notification
@@ -46,7 +47,7 @@ def send(
     pause_until = config.get("pause_until")
     if pause_until:
         try:
-            if date.today() <= date.fromisoformat(pause_until):
+            if get_current_datetime().date() <= date.fromisoformat(pause_until):
                 return
         except ValueError:
             pass
@@ -55,7 +56,7 @@ def send(
         until = gp.get(goal)
         if until:
             try:
-                if date.today() <= date.fromisoformat(until):
+                if get_current_datetime().date() <= date.fromisoformat(until):
                     return
             except ValueError:
                 pass

--- a/tests/unit/test_debug_mode.py
+++ b/tests/unit/test_debug_mode.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from loopbloom import __main__ as main
+from loopbloom.core.models import GoalArea
+from loopbloom.storage.json_store import JSONStore
+
+
+def test_debug_flag_enables_verbose_logging(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(main.cli, ["--debug", "goal", "add", "Logging Goal"], env=env)
+    assert res.exit_code == 0
+    assert "Debug mode is ON" in res.output
+
+
+def test_time_override_with_env_var(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    JSONStore(path=Path(env["LOOPBLOOM_DATA_PATH"])).save(
+        [GoalArea(name="G", micro_goals=[])]
+    )
+    monkeypatch.setenv("LOOPBLOOM_DEBUG_DATE", "2025-03-15")
+    res = runner.invoke(main.cli, ["--debug", "checkin", "G"], env=env)
+    assert res.exit_code == 0
+    assert "Check-in recorded for date: 2025-03-15" in res.output
+
+
+def test_dry_run_prevents_saving(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+    res = runner.invoke(main.cli, ["--dry-run", "goal", "add", "Dry Goal"], env=env)
+    assert res.exit_code == 0
+    assert "DRY RUN" in res.output
+    data_file = Path(env["LOOPBLOOM_DATA_PATH"])
+    assert not data_file.exists() or json.loads(data_file.read_text() or "[]") == []


### PR DESCRIPTION
## Summary
- add AppContext and global flags for `--debug` and `--dry-run`
- implement debug logging and dry-run handling in CLI helpers
- add time override service
- provide `debug-state` command for dumping raw data
- update documentation for new debugging features
- add unit tests for debug mode functionality

## Testing
- `./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_686ca0a950c08322af7407cf649589f5