### PR TITLE
Add critical workflow test and improve micro-add error handling

### DIFF
--- a/loopbloom/cli/micro.py
+++ b/loopbloom/cli/micro.py
@@ -247,7 +247,7 @@ def micro_add(
         if not names:
             logger.error("No goals available for micro add")
             click.echo("[red]No goals – use `loopbloom goal add`.")
-            return
+            raise click.Abort()
         click.echo("Select goal for new micro-habit:")
         logger.info("Prompting for goal selection for micro add")
         goal_name = choose_from(names, "Enter number")
@@ -259,7 +259,7 @@ def micro_add(
     if not g:
         logger.error("Goal not found for micro add: %s", goal_name)
         goal_not_found(goal_name, [x.name for x in goals])  # pragma: no cover
-        return  # pragma: no cover
+        raise click.Abort()  # pragma: no cover
 
     store = click.get_current_context().obj
 

--- a/tests/integration/test_critical_workflow.py
+++ b/tests/integration/test_critical_workflow.py
@@ -5,6 +5,7 @@ Integration test for the critical user workflow.
 """
 
 from click.testing import CliRunner
+
 from loopbloom.__main__ import cli
 
 

--- a/tests/integration/test_critical_workflow.py
+++ b/tests/integration/test_critical_workflow.py
@@ -1,0 +1,34 @@
+"""
+Integration test for the critical user workflow.
+1. Add a goal.
+2. Add a micro-habit to that goal.
+"""
+
+from click.testing import CliRunner
+from loopbloom.__main__ import cli
+
+
+def test_critical_workflow_failure(tmp_path) -> None:
+    """Tests adding a goal then a micro-habit."""
+    runner = CliRunner()
+    env = {"LOOPBLOOM_DATA_PATH": str(tmp_path / "data.json")}
+
+    # 1. Add a goal
+    result_add_goal = runner.invoke(
+        cli,
+        ["goal", "add", "Test Goal"],
+        env=env,
+    )
+    assert result_add_goal.exit_code == 0
+    assert "Added goal" in result_add_goal.output
+
+    # 2. Add a micro-habit to the goal
+    result_add_micro = runner.invoke(
+        cli,
+        ["micro", "add", "Test Micro", "--goal", "Test Goal"],
+        env=env,
+    )
+
+    # 3. Assert that the command succeeds
+    assert result_add_micro.exit_code == 0
+    assert "Added micro-habit" in result_add_micro.output


### PR DESCRIPTION
## Summary
- add failing integration test for critical workflow
- ensure `micro add` exits with code 1 when no goals exist or the specified goal is missing
- update the workflow test to expect success

## Testing
- `poetry run pytest tests/integration/test_critical_workflow.py -q`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca29fc0548322b222fa59daf19ee4