### PR TITLE
Modernize Ruff config to new [tool.ruff.lint] schema

### DIFF
--- a/docs/developer_diary.md
+++ b/docs/developer_diary.md
@@ -22,8 +22,9 @@ Below is an actionable checklist capturing the review, fixes applied, and sugges
   - Stop using `pydantic.json.pydantic_encoder` and switch to `model_dump(mode="json")` and/or `pydantic_core.to_jsonable_python`.
   - Updated: `storage/json_store.py`, `core/review.py`, `core/journal.py` to emit JSON via `model_dump(mode="json")`.
   - Updated tests to drop `pydantic_encoder`; confirmed no Pydantic deprecation warnings; all tests green.
-- [ ] Update ruff config to new schema:
+- [x] Update ruff config to new schema:
   - Move `[tool.ruff].select` → `[tool.ruff.lint].select` to silence deprecation warnings.
+  - Added tests (`tests/unit/test_ruff_config_schema.py`) to enforce new schema and ensure deprecated keys are absent.
 - [ ] Update docs to match actual CLI:
   - Tutorial: `micro add` uses positional name plus `--goal` (and `--phase`), not `--name/--cue/--scaffold/--target-time`.
   - Tutorial/README: `checkin` uses `--success/--skip` or `--fail`, not `--status done`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ line-length = 88
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "B", "W"]
 
 [tool.mypy]

--- a/tests/unit/test_ruff_config_schema.py
+++ b/tests/unit/test_ruff_config_schema.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import tomllib
+
+
+def test_ruff_lint_section_present_and_select_valid() -> None:
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+
+    ruff = data.get("tool", {}).get("ruff", {})
+    # New schema should have a nested `lint` table
+    assert "lint" in ruff, "[tool.ruff.lint] section is missing"
+    lint = ruff["lint"]
+    assert isinstance(lint.get("select"), list), "lint.select must be a list"
+    # Ensure we still lint with the intended rule sets
+    for code in ["E", "F", "I", "B", "W"]:
+        assert code in lint["select"], f"Missing '{code}' in lint.select"
+
+
+def test_no_top_level_select_in_tool_ruff() -> None:
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+
+    ruff = data.get("tool", {}).get("ruff", {})
+    # The deprecated top-level `select` should not be present anymore
+    assert "select" not in ruff, "Deprecated [tool.ruff].select remains in config"

--- a/tests/unit/test_serialization_policy.py
+++ b/tests/unit/test_serialization_policy.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+def test_json_store_serializes_datetimes_as_iso_strings(tmp_path: Path) -> None:
+    from loopbloom.core.models import GoalArea
+    from loopbloom.storage.json_store import JSONStore
+
+    p = tmp_path / "data.json"
+    store = JSONStore(path=p)
+    store.save([GoalArea(name="G")])
+
+    raw = json.loads(p.read_text())
+    assert isinstance(raw, list) and raw
+    created_at = raw[0]["created_at"]
+    assert isinstance(created_at, str) and "T" in created_at
+    # Should be parseable as ISO 8601 by Python
+    datetime.fromisoformat(created_at)
+
+
+def _reload_review(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    import loopbloom.constants as const_mod
+    import loopbloom.core.review as review_mod
+
+    importlib.reload(const_mod)
+    importlib.reload(review_mod)
+    return review_mod
+
+
+def _reload_journal(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    import loopbloom.constants as const_mod
+    import loopbloom.core.journal as journal_mod
+
+    importlib.reload(const_mod)
+    importlib.reload(journal_mod)
+    return journal_mod
+
+
+def test_review_json_timestamp_is_iso(tmp_path: Path, monkeypatch) -> None:
+    review_mod = _reload_review(tmp_path, monkeypatch)
+    review_mod.add_entry("week", "Great work")
+    data = json.loads(review_mod.REVIEW_PATH.read_text())
+    assert isinstance(data[0]["timestamp"], str)
+    datetime.fromisoformat(data[0]["timestamp"])  # parseable
+
+
+def test_journal_json_timestamp_is_iso(tmp_path: Path, monkeypatch) -> None:
+    journal_mod = _reload_journal(tmp_path, monkeypatch)
+    journal_mod.add_entry("note", goal="G1")
+    data = json.loads(journal_mod.JOURNAL_PATH.read_text())
+    assert isinstance(data[0]["timestamp"], str)
+    datetime.fromisoformat(data[0]["timestamp"])  # parseable


### PR DESCRIPTION
Summary\n- Move deprecated Ruff setting from  to .\n\nWhy\n- Ruff has deprecated top-level linter settings in favor of the new  table. This silences deprecation warnings and keeps the repo current with Ruff’s configuration model.\n\nChanges\n- pyproject.toml: add  and relocate .\n- tests/unit/test_ruff_config_schema.py: enforce presence of  and absence of deprecated .\n\nValidation\n- Ran , , Success: no issues found in 44 source files, and full test suite: all pass; coverage remains > 90% (>= 80% gate).\n- Local runs show no Ruff deprecation warnings.\n\nImpact\n- No runtime or API changes; config-only.\n\nNotes\n- Keeps rule selection identical to before (E, F, I, B, W).