### PR TITLE
Docs: align CLI flag usage in README/TUTORIAL with actual interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Traditional trackers assume unlimited will-power and demand elaborate setups. **
 | **Tree View**           | `tree` shows your goals, phases, and micro-habits. |
 | **Exports**             | \`export csv/json                                                  | 
 | **Pluggable Storage**   | JSON by default; SQLite plugin for power-users.                    | 
-| **100 % Test Coverage** | Every line & branch, enforced by CI.                               | 
+| **Quality Gates**        | ≥ 80% coverage enforced; type checks and linting in CI.           | 
 
 <a id="install"></a>
 
@@ -117,7 +117,7 @@ loopbloom micro add "Wake up at 08:00" --goal "Sleep Hygiene"
 
 # 3  Begin tracking each day
 # This command will find the currently active micro-habit under "Sleep Hygiene" (which is "Wake up at 08:00") and record a successful check-in for it.
-loopbloom checkin --goal "Sleep Hygiene" --status done --note "Groggy but did it!"
+loopbloom checkin "Sleep Hygiene" --success --note "Groggy but did it!"
 ```
 
 The CLI replies with something like:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -28,11 +28,10 @@ You should see confirmation similar to:
 
 ## 3. Add a Micro-Habit
 
-Next, define a small action that takes five minutes or less:
+Next, define a small action that takes five minutes or less. The name is positional; add an optional goal (and phase if you want):
 
 ```bash
-loopbloom micro add --goal "Exercise" --name "Walk 5 min" \
-                   --cue "After lunch" --scaffold "Shoes ready" --target-time 13:00
+loopbloom micro add "Walk 5 min" --goal "Exercise"
 ```
 
 The CLI replies with something like:
@@ -46,7 +45,7 @@ The CLI replies with something like:
 Record whether you completed the micro-habit:
 
 ```bash
-loopbloom checkin --goal "Exercise" --status done --note "Sunny walk"
+loopbloom checkin Exercise --success --note "Sunny walk"
 ```
 
 Sample output:

--- a/tests/test_docs_cli_consistency.py
+++ b/tests/test_docs_cli_consistency.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_docs_do_not_use_outdated_flags() -> None:
+    readme = _text("README.md")
+    tutorial = _text("TUTORIAL.md")
+    body = readme + "\n" + tutorial
+
+    # Flags that should no longer appear anywhere
+    forbidden = [
+        "--status",  # replaced by --success/--skip or --fail
+        "--name ",  # micro add uses positional name
+        "--cue ",
+        "--scaffold ",
+        "--target-time",
+    ]
+    for flag in forbidden:
+        assert flag not in body, f"Outdated flag present in docs: {flag}"
+
+
+def test_readme_quick_start_uses_supported_checkin_flags() -> None:
+    readme = _text("README.md")
+    # Expect one of the supported flags in the checkin example
+    assert (
+        "--success" in readme or "--skip" in readme or "--fail" in readme
+    ), "README checkin example should use --success/--skip/--fail"
+
+
+def test_readme_testing_section_claims_80_percent_gate() -> None:
+    readme = _text("README.md")
+    # Ensure we don't claim 100% coverage anywhere
+    assert "100 % Test Coverage" not in readme
+    # Ensure Testing & CI section mentions 80 %
+    assert "80 %" in readme or "80%" in readme
+
+
+def test_tutorial_micro_add_uses_positional_name() -> None:
+    tutorial = _text("TUTORIAL.md")
+    # Look for an example resembling: loopbloom micro add "Name" --goal ...
+    assert re.search(r"loopbloom\s+micro\s+add\s+\".+\"", tutorial)


### PR DESCRIPTION
Summary\n- Align documentation with current CLI semantics.\n\nChanges\n- README:\n  - Quick Start: use  instead of deprecated  flag.\n  - Feature table: replace "100% Test Coverage" claim with a quality gate description (≥ 80% coverage; type checks + linting).\n- TUTORIAL:\n  -  uses a positional name with optional  (and ), removing stale flags ().\n  - Check-in example updated to .\n- Tests: add  enforcing absence of deprecated flags and presence of supported patterns in docs.\n\nWhy\n- Prevent user confusion and keep docs in lockstep with the CLI.\n- Add guardrails so future changes don’t reintroduce stale flags.\n\nValidation\n- , , Success: no issues found in 44 source files, and full test suite pass locally: 127 tests passing.\n\nImpact\n- Docs and tests only; no runtime changes.