### PR TITLE
Quality: exhaustive CLI help coverage + docs/code alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,8 @@ Quick checklist before a PR:
 - Run checks: `./scripts/pre-commit`
 
 Only open a PR once `./scripts/pre-commit` passes end-to-end. If any step fails, fix the issues and rerun until green.
+
+Documentation alignment requirement:
+- When you change code that affects user-facing behavior (CLI flags, command names, output formats, examples), you must update the documentation in the same change set.
+- Keep `README.md`, `TUTORIAL.md`, and `USER_GUIDE.md` consistent with the current CLI. Examples must reflect real commands and supported flags.
+- Prefer adding or updating lightweight tests that enforce doc–CLI consistency (see `tests/test_docs_cli_consistency.py`).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Traditional trackers assume unlimited will-power and demand elaborate setups. **
 | **Smart Progression**   | ≥ 80 % over 14 days triggers *advance* prompt.                     | 
 | **Guided Coping**       | `cope` launches YAML Q\&A scripts for overwhelm.                   | 
 | **Gentle Banners**      | `summary` prints streaks, nudges, celebrations. Optional `--goal`. | 
-| **Tree View**           | `tree` shows your goals, phases, and micro-habits. |
+| **Tree View**           | `tree` shows your goals, phases, and micro-habits. Status glyphs mark active/complete/cancelled; add `--ascii` for ASCII-only. |
 | **Exports**             | \`export csv/json                                                  | 
 | **Pluggable Storage**   | JSON by default; SQLite plugin for power-users.                    | 
 | **Quality Gates**        | ≥ 80% coverage enforced; type checks and linting in CI.           | 
@@ -221,6 +221,16 @@ DATA & CONFIG
   loopbloom export --fmt csv|json --out progress.csv
   loopbloom config set key val | get key | view
 ```
+
+### Global Flags
+
+These flags work with any command and can be placed before the subcommand:
+
+- `--debug`   Enable verbose logging.
+- `--dry-run` Simulate without writing changes.
+- `--plain`/`--no-color` Disable colored output for stable logs.
+- `--data-path PATH` Use a specific data file for this session; the file
+  extension selects storage automatically (`.json` → JSON, `.db`/`.sqlite` → SQLite).
 
 <a id="config"></a>
 

--- a/docs/user_feedback.md
+++ b/docs/user_feedback.md
@@ -1,5 +1,10 @@
 # User Feedback for LoopBloom CLI
 
+Note: This document captures historical feedback, some of which predates recent
+improvements. Installation, command names, and flags referenced below may have
+since been updated. Refer to the README, Tutorial, and User Guide for the
+canonical, up-to-date usage.
+
 ## Evaluation Results
 
 I performed a series of workflow simulations based on the `README.md` to evaluate the LoopBloom CLI.

--- a/tests/unit/test_cli_all_commands_help.py
+++ b/tests/unit/test_cli_all_commands_help.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def test_all_top_level_commands_have_help(monkeypatch) -> None:
+    """Every registered top-level command should provide --help successfully.
+
+    This ensures new commands are at least minimally documented and wired up.
+    """
+    from loopbloom import __main__ as main
+
+    # Isolate any filesystem writes under a temp path
+    monkeypatch.setenv("LOOPBLOOM_DATA_PATH", str(Path.cwd() / ".tmp-x" / "data.json"))
+
+    runner = CliRunner()
+    # Ensure commands are registered
+    commands = dict(main.cli.commands)
+    assert commands, "No commands registered on CLI"
+
+    for name in commands.keys():
+        res = runner.invoke(
+            main.cli, [name, "--help"]
+        )  # groups and commands both support --help
+        assert res.exit_code == 0, f"--help failed for command: {name}"


### PR DESCRIPTION
This PR strengthens our quality bar for tests and documentation:

- Add unit test ensuring every top-level CLI command exposes `--help` successfully, catching unregistered or undocumented commands early.
- Update README to document global flags (`--debug`, `--dry-run`, `--plain/--no-color`, `--data-path`) and to mention Tree status glyphs with an ASCII fallback via `--ascii`.
- Add a short preface to `docs/user_feedback.md` clarifying it is historical and that README/Tutorial/User Guide remain the canonical sources.
- Extend `AGENTS.md` with a docs-alignment rule: any user-facing change must be reflected in README and docs; encourage lightweight tests to enforce consistency.

Local quality gate:
- `./scripts/pre-commit` passes locally (Black/Ruff/Mypy/Pytest; ~91% coverage).

Rationale:
- Ensures user-facing surfaces (CLI & docs) stay in lockstep and reduces regressions.
- Provides a minimal “exhaustive” baseline by verifying help exists for all commands, while keeping room for deeper command-specific tests to continue growing.

Follow-ups (optional):
- Snapshot tests for `tree`/`summary` in Unicode vs ASCII.
- Expand docs consistency tests to validate example snippets run under Click runner.
